### PR TITLE
Mylin/add RxJS ICD tests part1

### DIFF
--- a/src/test/ANIMATOR_CONTOUR.test.ts
+++ b/src/test/ANIMATOR_CONTOUR.test.ts
@@ -1,0 +1,438 @@
+import { CARTA } from "carta-protobuf";
+import * as Long from "long";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+
+let connectTimeout = config.timeout.connection;
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile;
+let playAnimatorTimeout = config.timeout.playAnimator
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setContour: CARTA.ISetContourParameters;
+    startAnimation: CARTA.IStartAnimation[];
+    stopAnimation: CARTA.IStopAnimation[];
+    animationFlowControl: CARTA.IAnimationFlowControl[];
+    setImageChannel: CARTA.ISetImageChannels[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setContour: {
+        fileId: 0,
+        referenceFileId: 0,
+        imageBounds: {
+            xMin: 0, xMax: 640,
+            yMin: 0, yMax: 800,
+        },
+        levels: [-0.01, 0.01],
+        smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+        smoothingFactor: 4,
+        decimationFactor: 4,
+        compressionLevel: 8,
+        contourChunkSize: 100000,
+    },
+    startAnimation:
+        [
+            {
+                fileId: 0,
+                startFrame: { channel: 1, stokes: 0 },
+                firstFrame: { channel: 0, stokes: 0 },
+                lastFrame: { channel: 24, stokes: 0 },
+                deltaFrame: { channel: 1, stokes: 0 },
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [0],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 9,
+                },
+                looping: false,
+                reverse: false,
+                frameRate: 5,
+            },
+            {
+                fileId: 0,
+                startFrame: { channel: 20, stokes: 0 },
+                firstFrame: { channel: 0, stokes: 0 },
+                lastFrame: { channel: 24, stokes: 0 },
+                deltaFrame: { channel: -1, stokes: 0 },
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [0],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 9,
+                },
+                looping: false,
+                reverse: false,
+                frameRate: 5,
+            },
+        ],
+    stopAnimation:
+        [
+            {
+                fileId: 0,
+                endFrame: { channel: 10, stokes: 0 },
+            },
+            {
+                fileId: 0,
+                endFrame: { channel: 10, stokes: 0 },
+            },
+        ],
+    animationFlowControl:
+        [
+            {
+                fileId: 0,
+                animationId: 1,
+            },
+            {
+                fileId: 0,
+                animationId: 2,
+            },
+        ],
+    setImageChannel:
+        [
+            {
+                fileId: 0,
+                channel: 0,
+                stokes: 0,
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [0],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 11,
+                },
+            },
+            {
+                fileId: 0,
+                channel: 20,
+                stokes: 0,
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [0],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 11,
+                },
+            },
+        ],
+};
+
+describe("ANIMATOR_CONTOUR: Testing animation playback with contour lines", () => {
+
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        let basepath: string;
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            let OpenFileResponse: CARTA.IOpenFileAck;
+        test(`"${assertItem.openFile.file}" OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`,async () => {
+            assertItem.openFile.directory = basepath + "/" + assertItem.filelist.directory;
+            OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+            expect(OpenFileResponse.success).toEqual(true);
+
+            let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            expect(RegionHistrogramDataResponse.length).toEqual(1);        
+        },openFileTimeout);
+
+        test(`Preparation`, async() => {
+            msgController.addRequiredTiles(assertItem.addTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2);
+            
+            msgController.setContourParameters(assertItem.setContour);
+            let ContourImageDataResponse = await Stream(CARTA.ContourImageData, assertItem.setContour.levels.length);
+        }, readFileTimeout)
+        });
+        
+        describe(`(Case 1):Play some channels forwardly`, ()=>{
+            test(`Preparation`, async () => {
+                msgController.setChannels(assertItem.setImageChannel[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.setImageChannel[0].requiredTiles.tiles.length + 2);
+            });
+
+            let regionHistogramData: CARTA.RegionHistogramData[] = [];
+            let RasterTileSequence: number[] = [];
+            let HistogramSequence: number[] = [];
+            let ContourSequence: number[] = [];
+            test(`Image should return one after one and the last channel is correct:`, async () => {
+                let StartAnimationResponse: CARTA.IStartAnimationAck;
+                StartAnimationResponse = await msgController.startAnimation(assertItem.startAnimation[0]);
+                expect(StartAnimationResponse.success).toEqual(true);
+
+                for (let i = 0; i < assertItem.stopAnimation[0].endFrame.channel; i++) {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let resRegionHistogramData = msgController.histogramStream.pipe(take(1)).subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            HistogramSequence.push(data.channel)
+                        }
+                    });
+                    let resContourImageData = msgController.contourStream.pipe(take(2)).subscribe({
+                        next: (data) => {
+                            ContourSequence.push(data.channel)
+                        }
+                    });
+
+                    let rasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+                    let currentChannel = rasterTileDataResponse[0].channel;
+                    RasterTileSequence.push(currentChannel);
+
+                    msgController.sendAnimationFlowControl(
+                        {
+                            ...assertItem.animationFlowControl[0],
+                            receivedFrame: {
+                                channel: currentChannel,
+                                stokes: 0
+                            },
+                            timestamp: Long.fromNumber(Date.now()),
+                        }
+                    );
+                }
+
+                // Pick up the streaming messages
+                // Channel 11 & 12: RasterTileData + RasterTileSync(start & end) + RegionHistogramData
+                let RegionHistogramDataChannel11: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe(data => {
+                    RegionHistogramDataChannel11.push(data)
+                });
+                let RasterTileDataChannel11 = await Stream(CARTA.RasterTileData,3);
+
+                let RegionHistogramDataChannel12: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe(data => {
+                    RegionHistogramDataChannel12.push(data)
+                });
+                let RasterTileDataChannel12 = await Stream(CARTA.RasterTileData,3);
+
+
+                // // Send StopAnimator
+                msgController.stopAnimation(assertItem.stopAnimation[0]);
+                msgController.setChannels(assertItem.setImageChannel[0]);  
+
+                let lastRegionHistogramData: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe({
+                    next: (data) => {
+                        lastRegionHistogramData.push(data)
+                    },
+                    // complete: () => {
+                    //     console.log(lastRegionHistogramData)
+                    // }
+                });
+                let lastContourImageData: CARTA.ContourImageData[] = [];
+                msgController.contourStream.pipe(take(2)).subscribe({
+                    next: (data) => {
+                        lastContourImageData.push(data)
+                    },
+                    // complete: () => {
+                    //     console.log(lastContourImageData)
+                    // }
+                });
+          
+                let lastRasterTileData = await Stream(CARTA.RasterTileData,3);
+            }, playAnimatorTimeout);
+
+            test(`Received RasterTileData channels should be in sequence`, async () => {
+                console.warn(`(Step 1) Sequent channel index: ${RasterTileSequence}`);
+                RasterTileSequence.map((id, index) => {
+                    let channelId = (index + assertItem.startAnimation[0].startFrame.channel + assertItem.startAnimation[0].deltaFrame.channel) - 1.;
+                    expect(id).toEqual(channelId);
+                });
+            });
+
+            test(`Received ContourData channels should be in sequence`, async () => {
+                for (let i = 1; i <= assertItem.stopAnimation[0].endFrame.channel; i++) {
+                    expect(ContourSequence[(i-1)*2]).toEqual(i);
+                    expect(ContourSequence[(i-1)*2+1]).toEqual(i);
+                }
+            });
+
+            test(`Received RegionHistogramData channels should be in sequence`, async () => {
+                for (let i = 1; i <= assertItem.stopAnimation[0].endFrame.channel; i++) {
+                    expect(HistogramSequence[i-1]).toEqual(i);
+                }
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});
+
+describe("ANIMATOR_CONTOUR: Testing animation playback with contour lines", () => {
+
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        let basepath: string;
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            let OpenFileResponse: CARTA.IOpenFileAck;
+        test(`"${assertItem.openFile.file}" OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`,async () => {
+            assertItem.openFile.directory = basepath + "/" + assertItem.filelist.directory;
+            OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+            expect(OpenFileResponse.success).toEqual(true);
+
+            let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            expect(RegionHistrogramDataResponse.length).toEqual(1);        
+        },openFileTimeout);
+
+        test(`Preparation`, async() => {
+            msgController.addRequiredTiles(assertItem.addTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2)
+            
+            msgController.setContourParameters(assertItem.setContour);
+            let ContourImageDataResponse = await Stream(CARTA.ContourImageData, assertItem.setContour.levels.length);
+        }, readFileTimeout)
+        });
+
+        describe(`(Case 2) Play some channels backwardly`, () => {
+            test(`Preparation`, async () => {
+                msgController.setChannels(assertItem.setImageChannel[1]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.setImageChannel[1].requiredTiles.tiles.length + 2);
+            });
+
+            let regionHistogramData: CARTA.RegionHistogramData[] = [];
+            let RasterTileSequence: number[] = [];
+            let HistogramSequence: number[] = [];
+            let ContourSequence: number[] = [];
+            test(`Image should return one after one and the last channel is correct:`, async () => {
+                let StartAnimationResponse: CARTA.IStartAnimationAck;
+                StartAnimationResponse = await msgController.startAnimation(assertItem.startAnimation[1]);
+                expect(StartAnimationResponse.success).toEqual(true);
+
+                for (let i = assertItem.startAnimation[1].startFrame.channel; i > assertItem.stopAnimation[1].endFrame.channel - 1; i--) {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let resRegionHistogramData = msgController.histogramStream.pipe(take(1)).subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            HistogramSequence.push(data.channel)
+                        }
+                    });
+                    let resContourImageData = msgController.contourStream.pipe(take(2)).subscribe({
+                        next: (data) => {
+                            ContourSequence.push(data.channel)
+                        }
+                    });
+
+                    let rasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+                    let currentChannel = rasterTileDataResponse[0].channel;
+                    RasterTileSequence.push(currentChannel);
+
+                    msgController.sendAnimationFlowControl(
+                        {
+                            ...assertItem.animationFlowControl[0],
+                            receivedFrame: {
+                                channel: currentChannel,
+                                stokes: 0
+                            },
+                            timestamp: Long.fromNumber(Date.now()),
+                        }
+                    );
+                }
+
+                // Pick up the streaming messages
+                // Channel 8 & 7: RasterTileData + RasterTileSync(start & end) + RegionHistogramData
+                let RegionHistogramDataChannel8: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe(data => {
+                    RegionHistogramDataChannel8.push(data)
+                });
+                let RasterTileDataChannel8 = await Stream(CARTA.RasterTileData,3);
+
+                let RegionHistogramDataChannel7: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe(data => {
+                    RegionHistogramDataChannel7.push(data)
+                });
+                let RasterTileDataChannel7 = await Stream(CARTA.RasterTileData,3);
+
+                // // Send StopAnimator
+                msgController.stopAnimation(assertItem.stopAnimation[1]);
+                msgController.setChannels(assertItem.setImageChannel[1]);  
+
+                let lastRegionHistogramData: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe({
+                    next: (data) => {
+                        lastRegionHistogramData.push(data)
+                    },
+                    // complete: () => {
+                    //     console.log(lastRegionHistogramData)
+                    // }
+                });
+                let lastContourImageData: CARTA.ContourImageData[] = [];
+                msgController.contourStream.pipe(take(2)).subscribe({
+                    next: (data) => {
+                        lastContourImageData.push(data)
+                    },
+                    // complete: () => {
+                    //     console.log(lastContourImageData)
+                    // }
+                });
+          
+                let lastRasterTileData = await Stream(CARTA.RasterTileData,3);
+            }, playAnimatorTimeout);
+
+            test(`Received RasterTileData channels should be in sequence`, async () => {
+                console.warn(`(Step 2) Sequent channel index: ${RasterTileSequence}`);
+                RasterTileSequence.map((id, index) => {
+                    let channelId = -index + assertItem.startAnimation[1].startFrame.channel - 1;
+                    expect(id).toEqual(channelId);
+                });
+            });
+
+            test(`Received ContourData channels should be in sequence`, async () => {
+                let index = 1;
+                for (let i = assertItem.startAnimation[1].startFrame.channel -1 ; i > assertItem.stopAnimation[1].endFrame.channel - 2; i--) {
+                    expect(ContourSequence[(index-1)*2]).toEqual(i);
+                    expect(ContourSequence[(index-1)*2+1]).toEqual(i);
+                    index++;
+                }
+            });
+
+            test(`Received RegionHistogramData channels should be in sequence`, async () => {
+                let index = 1;
+                for (let i = assertItem.startAnimation[1].startFrame.channel -1 ; i > assertItem.stopAnimation[1].endFrame.channel - 2; i--) {
+                    expect(HistogramSequence[index-1]).toEqual(i);
+                    index++;
+                }
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
+++ b/src/test/ANIMATOR_CONTOUR_MATCH.test.ts
@@ -1,0 +1,306 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import * as Long from "long";
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+
+let connectTimeout = config.timeout.connection;
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let openFileTimeout: number = config.timeout.openFile;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile[];
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setContour: CARTA.ISetContourParameters[];
+    startAnimation: CARTA.IStartAnimation;
+    stopAnimation: CARTA.IStopAnimation;
+    setImageChannel: CARTA.ISetImageChannels[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: [
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.fits",
+            hdu: "",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.image",
+            hdu: "",
+            fileId: 1,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setContour: [
+        {
+            fileId: 0,
+            referenceFileId: 1,
+            imageBounds: {
+                xMin: 0, xMax: 640,
+                yMin: 0, yMax: 800,
+            },
+            levels: [-0.01, 0.01],
+            smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+            smoothingFactor: 4,
+            decimationFactor: 4,
+            compressionLevel: 8,
+            contourChunkSize: 100000,
+        },
+        {
+            fileId: 1,
+            referenceFileId: 1,
+            imageBounds: {
+                xMin: 0, xMax: 640,
+                yMin: 0, yMax: 800,
+            },
+            levels: [-0.01, 0.01],
+            smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+            smoothingFactor: 4,
+            decimationFactor: 4,
+            compressionLevel: 8,
+            contourChunkSize: 100000,
+        },
+    ],
+    startAnimation: {
+        fileId: 0,
+        startFrame: { channel: 1, stokes: 0 },
+        firstFrame: { channel: 0, stokes: 0 },
+        lastFrame: { channel: 24, stokes: 0 },
+        deltaFrame: { channel: 1, stokes: 0 },
+        requiredTiles: {
+            fileId: 0,
+            tiles: [0],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 9,
+        },
+        looping: false,
+        reverse: false,
+        frameRate: 5,
+        matchedFrames: {
+            [1]: {
+                frameNumbers: [
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                    20, 21, 22, 23, 24,
+                ],
+            },
+        },
+    },
+    stopAnimation:
+    {
+        fileId: 0,
+        endFrame: { channel: 10, stokes: 0 },
+    },
+    setImageChannel: [
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+        {
+            fileId: 1,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+    ],
+};
+
+
+let basepath: string;
+describe("ANIMATOR_CONTOUR: Testing animation playback with contour lines", () => {
+
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+        });
+
+
+        describe(`Open two images:`, () => {
+            test(`Check open successful`,async () => {
+                assertItem.fileOpen[0].directory = basepath + "/" + assertItem.filelist.directory;
+                assertItem.fileOpen[1].directory = basepath + "/" + assertItem.filelist.directory;
+
+                let OpenFileResponse1 = await msgController.loadFile(assertItem.fileOpen[0]);
+                expect(OpenFileResponse1.success).toEqual(true);
+
+                let RegionHistrogramDataResponse1 = await Stream(CARTA.RegionHistogramData,1);
+
+                let OpenFileResponse2 = await msgController.loadFile(assertItem.fileOpen[1]);
+                expect(OpenFileResponse2.success).toEqual(true);
+
+                let RegionHistrogramDataResponse2 = await Stream(CARTA.RegionHistogramData,1);
+            }, openFileTimeout);
+        });
+
+        describe(`Preparation`, () => {
+            test(`Contour set`, async () => {
+                msgController.addRequiredTiles(assertItem.addTilesReq);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2);
+                
+                msgController.setContourParameters(assertItem.setContour[0]);
+                let ContourImageDataResponse1 = await Stream(CARTA.ContourImageData, assertItem.setContour[0].levels.length);
+
+                msgController.setContourParameters(assertItem.setContour[1]);
+                let ContourImageDataResponse2 = await Stream(CARTA.ContourImageData, assertItem.setContour[1].levels.length);
+
+            });
+        });
+
+        describe(`Play some channels forwardly`, () => {
+            let regionHistogramData: CARTA.RegionHistogramData[] = [];
+            let sequence: number[] = [];
+            let contourImageData: CARTA.ContourImageData[] = [];
+            let HistogramSequence: number[] = [];
+            let ContourSequence: number[] = [];
+            test(`Assert ContourImageData.channel = RasterTileData.channel`, async () => {
+                let StartAnimationResponse = await msgController.startAnimation(assertItem.startAnimation);
+                expect(StartAnimationResponse.success).toEqual(true);
+
+                for (let i = 0; i < assertItem.stopAnimation.endFrame.channel; i++) {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let resRegionHistogramData = msgController.histogramStream.pipe(take(2)).subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            HistogramSequence.push(data.channel)
+                        }
+                    });
+                    let rasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+                    let resContourImageData = msgController.contourStream.pipe(take(4)).subscribe({
+                        next: (data) => {
+                            contourImageData.push(data)
+                            ContourSequence.push(data.channel)
+                        },
+                    });
+                    let currentChannel = rasterTileDataResponse[0].channel;
+                    sequence.push(currentChannel);
+                    msgController.sendAnimationFlowControl(
+                        {
+                            fileId: 0,
+                            animationId: 0,
+                            receivedFrame: {
+                                channel: currentChannel,
+                                stokes: 0
+                            },
+                            timestamp: Long.fromNumber(Date.now()),
+                        }
+                    );
+                }
+
+                // // Pick up the streaming messages
+                // // Channel 11 & 12: RasterTileData + RasterTileSync(start & end) + RegionHistogramData
+                // let RegionHistogramDataChannel11: CARTA.RegionHistogramData[] = [];
+                // msgController.histogramStream.pipe(take(1)).subscribe(data => {
+                //     RegionHistogramDataChannel11.push(data)
+                // });
+                // let ContourImageDataChannel11 = await Stream(CARTA.ContourImageData,4)
+                // console.log(ContourImageDataChannel11);
+                // let RasterTileDataChannel11 = await Stream(CARTA.RasterTileData,3);
+                // console.log(RasterTileDataChannel11);
+
+                // let RegionHistogramDataChannel12: CARTA.RegionHistogramData[] = [];
+                // msgController.histogramStream.pipe(take(1)).subscribe(data => {
+                //     RegionHistogramDataChannel12.push(data)
+                // });
+                // let ContourImageDataChannel12 = await Stream(CARTA.ContourImageData,4)
+                // console.log(ContourImageDataChannel12);
+                // let RasterTileDataChannel12 = await Stream(CARTA.RasterTileData,3);
+                // console.log(RasterTileDataChannel12)
+
+            });
+
+            test(`Assert the last channel = StopAnimation.endFrame`, async () => {
+                msgController.stopAnimation(assertItem.stopAnimation);
+                msgController.setChannels(assertItem.setImageChannel[0]);
+                let lastRegionHistogramData1: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe({
+                next: (data) => {
+                    lastRegionHistogramData1.push(data)
+                },
+                });
+                let lastContourImageData1: CARTA.ContourImageData[] = [];
+                msgController.contourStream.pipe(take(2)).subscribe({
+                next: (data) => {
+                    lastContourImageData1.push(data)
+                },
+                });
+          
+                let lastRasterTileData1 = await Stream(CARTA.RasterTileData,3);  
+
+                msgController.setChannels(assertItem.setImageChannel[1]);
+                let lastRegionHistogramData2: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe({
+                next: (data) => {
+                    lastRegionHistogramData2.push(data)
+                },
+                });
+                let lastContourImageData2: CARTA.ContourImageData[] = [];
+                msgController.contourStream.pipe(take(2)).subscribe({
+                next: (data) => {
+                    lastContourImageData2.push(data)
+                },
+                });
+          
+                let lastRasterTileData2 = await Stream(CARTA.RasterTileData,3);
+            });
+
+            test(`Received image channels should be in sequence`, async () => {
+                sequence.map((id, index) => {
+                    let channelId = (index + assertItem.startAnimation.startFrame.channel + assertItem.startAnimation.deltaFrame.channel);
+                    expect(id).toEqual(channelId-1);
+                });
+            });
+
+            test(`Assert a series of ContourImageData`, async () => {
+                for (let i = 2; i <= assertItem.stopAnimation.endFrame.channel; i++) {
+                    let testSet = contourImageData.filter(data => data.progress == 1 && data.channel == i);
+                    expect(testSet.length).toEqual(assertItem.setContour[0].levels.length * assertItem.fileOpen.length);
+                    expect(testSet.filter(data => data.fileId == 0).length).toEqual(assertItem.setContour[0].levels.length);
+                    expect(testSet.filter(data => data.fileId == 1).length).toEqual(assertItem.setContour[1].levels.length);
+                }
+                expect(contourImageData.length).toEqual(assertItem.stopAnimation.endFrame.channel * assertItem.setContour[0].levels.length * assertItem.fileOpen.length);
+                contourImageData.map(data => {
+                    expect(data.referenceFileId).toEqual(1);
+                });
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/ANIMATOR_DATA_STREAM.test.ts
+++ b/src/test/ANIMATOR_DATA_STREAM.test.ts
@@ -1,0 +1,201 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let changeChannelTimeout = config.timeout.changeChannel;
+let regionTimeout = config.timeout.region;
+
+interface AssertItem {
+    precisionDigits: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    filelist: CARTA.IFileListRequest;
+    cursor: CARTA.ISetCursor;
+    spatial: CARTA.ISetSpatialRequirements;
+    stats: CARTA.ISetStatsRequirements;
+    histogram: CARTA.ISetHistogramRequirements;
+    imageChannels: CARTA.ISetImageChannels[];
+}
+let assertItem: AssertItem = {
+    registerViewer:
+    {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    precisionDigits: 4,
+    cursor: {
+        fileId: 0,
+        point: { x: 319, y: 378 },
+    },
+    spatial: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}],
+    },
+    stats: {
+        fileId: 0,
+        regionId: -1,
+        statsConfigs:[
+            {coordinate:"z", statsTypes:[
+                CARTA.StatsType.NumPixels,
+                CARTA.StatsType.Sum,
+                CARTA.StatsType.FluxDensity,
+                CARTA.StatsType.Mean,
+                CARTA.StatsType.RMS,
+                CARTA.StatsType.Sigma,
+                CARTA.StatsType.SumSq,
+                CARTA.StatsType.Min,
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
+            ]}
+        ],
+    },
+    histogram: {
+        fileId: 0,
+        regionId: -1,
+        histograms: [{ channel: -1, numBins: -1 }],
+    },
+    imageChannels: [
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+        {
+            fileId: 0,
+            channel: 12,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+    ],
+}
+
+let basepath: string;
+describe("ANIMATOR_NAVIGATION: Testing using animator to see different frames/channels/stokes", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open images`, () => {
+            test(`Preparation`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                msgController.setCursor(assertItem.cursor.fileId, assertItem.cursor.point.x, assertItem.cursor.point.y);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                msgController.setChannels(assertItem.imageChannels[0]);
+                let RasterTileData = await Stream(CARTA.RasterTileData,3);
+            });
+
+            describe(`SET SPATIAL REQUIREMENTS`, () => {
+                test(`SPATIAL_PROFILE_DATA should arrive within ${regionTimeout} ms`, async () => {
+                    msgController.setSpatialRequirements(assertItem.spatial);
+                    let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+                }, regionTimeout);
+            });
+
+            describe("SET STATS REQUIREMENTS", () => {
+                test(`REGION_STATS_DATA should arrive within ${regionTimeout} ms`, async () => {
+                    msgController.setStatsRequirements(assertItem.stats);
+                    let RegionStatsDataResponse =  await Stream(CARTA.RegionStatsData,1);
+                }, regionTimeout);
+            });
+
+            describe(`SET HISTOGRAM REQUIREMENTS`, () => {
+                test(`REGION_HISTOGRAM_DATA should arrive within ${regionTimeout} ms`, async () => {
+                    msgController.setHistogramRequirements(assertItem.histogram);
+                    let RegionHistrogramDataResponse2 = await Stream(CARTA.RegionHistogramData,1)
+                }, regionTimeout);
+            });
+
+            describe("SET IMAGE CHANNELS", () => {
+                let lastRegionHistogramData: CARTA.RegionHistogramData[] = []; 
+                let lastRegionStatsData: CARTA.RegionStatsData[] = [];
+                let lastSpatialProfileData: CARTA.SpatialProfileData[] = [];
+                let lastRasterTileData: any = [];
+                test(`RASTER_TILE_DATA, SPATIAL_PROFILE_DATA, REGION_HISTOGRAM_DATA & REGION_STATS_DATA should arrive within ${changeChannelTimeout} ms`, async () => {
+                    msgController.setChannels(assertItem.imageChannels[1]);
+                    msgController.histogramStream.pipe(take(1)).subscribe({
+                        next: (data) => {
+                            lastRegionHistogramData.push(data)
+                        }
+                    });
+                    msgController.statsStream.pipe(take(1)).subscribe({
+                        next: (data) => {
+                            lastRegionStatsData.push(data)
+                        }
+                    })
+                    msgController.spatialProfileStream.pipe(take(1)).subscribe({
+                        next: (data) => {
+                            lastSpatialProfileData.push(data)
+                        }
+                    })
+                    lastRasterTileData = await Stream(CARTA.RasterTileData,3);
+                }, changeChannelTimeout);
+    
+                test(`RASTER_TILE_DATA.channel = ${assertItem.imageChannels[1].channel}`, () => {
+                    expect(lastRasterTileData[1].channel).toEqual(assertItem.imageChannels[1].channel);
+                });
+    
+                test(`REGION_HISTOGRAM_DATA.region_id = ${assertItem.histogram.regionId}`, () => {
+                    expect(lastRegionHistogramData[0].regionId).toEqual(assertItem.histogram.regionId);
+                });
+    
+                test(`REGION_STATS_DATA.region_id = ${assertItem.stats.regionId}`, () => {
+                    expect(lastRegionStatsData[0].regionId).toEqual(assertItem.stats.regionId);
+                });
+    
+                test(`REGION_STATS_DATA.channel = ${assertItem.imageChannels[1].channel}`, () => {
+                    expect(lastRegionStatsData[0].channel).toEqual(assertItem.imageChannels[1].channel);
+                });
+    
+                test(`SPATIAL_PROFILE_DATA.channel = ${assertItem.imageChannels[1].channel}`, () => {
+                    expect(lastSpatialProfileData[0].channel).toEqual(assertItem.imageChannels[1].channel);
+                });
+    
+                test(`SPATIAL_PROFILE_DATA.x = ${assertItem.cursor.point.x}`, () => {
+                    expect(lastSpatialProfileData[0].x).toEqual(assertItem.cursor.point.x);
+                });
+    
+                test(`SPATIAL_PROFILE_DATA.y = ${assertItem.cursor.point.y}`, () => {
+                    expect(lastSpatialProfileData[0].y).toEqual(assertItem.cursor.point.y);
+                });
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/ANIMATOR_NAVIGATION.test.ts
+++ b/src/test/ANIMATOR_NAVIGATION.test.ts
@@ -1,0 +1,277 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let changeChannelTimeout = config.timeout.changeChannel;
+let messageReturnTimeout = config.timeout.messageEvent;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpens: CARTA.IOpenFile[];
+    setImageChannels: CARTA.ISetImageChannels[];
+    changeImageChannels: CARTA.ISetImageChannels[];
+    regionHistogramDatas: CARTA.IRegionHistogramData[];
+    rasterTileDatas: CARTA.IRasterTileData[];
+}
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpens: [
+        {
+            directory: testSubdirectory,
+            file: "HH211_IQU.hdf5",
+            fileId: 0,
+            hdu: "0",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.hdf5",
+            fileId: 1,
+            hdu: "0",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    setImageChannels: [
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+                tiles: [0],
+            },
+        },
+        {
+            fileId: 1,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 1,
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+                tiles: [0],
+            },
+        },
+    ],
+    changeImageChannels: [
+        {
+            fileId: 0,
+            channel: 2,
+            stokes: 1,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+        {
+            fileId: 1,
+            channel: 12,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 1,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+        {
+            fileId: 0,
+            channel: 100,
+            stokes: 3,
+        },
+        {
+            fileId: 1,
+            channel: 100,
+            stokes: 1,
+        },
+        {
+            fileId: 2,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 2,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [0],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+    ],
+    regionHistogramDatas: [
+        {
+            fileId: 0,
+            stokes: 1,
+            regionId: -1,
+            progress: 1,
+            histograms: {},
+            channel: 2 ,
+        },
+        {
+            fileId: 1,
+            stokes: 0,
+            regionId: -1,
+            progress: 1,
+            histograms: {},
+            channel: 12 ,
+        },
+        {},
+        {},
+        {},
+        {
+            fileId: 0,
+            stokes: 0,
+            regionId: -1,
+            progress: 1,
+            histograms: {},
+            channel: 0 
+        },
+    ],
+    rasterTileDatas: [
+        {
+            fileId: 0,
+            channel: 2,
+            stokes: 1,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+        },
+        {
+            fileId: 1,
+            channel: 12,
+            stokes: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+        },
+        {
+            fileId: -1,
+        },
+        {
+            fileId: -1,
+        },
+        {
+            fileId: -1,
+        },
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+        },
+    ],
+}
+
+let basepath: string;
+describe("ANIMATOR_NAVIGATION: Testing using animator to see different frames/channels/stokes", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpens[0].directory = basepath + "/" + assertItem.filelist.directory;
+            assertItem.fileOpens[1].directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open images`, () => {
+            test(`Preparation`, async () => {
+                msgController.closeFile(-1);
+                for (let i = 0; i < assertItem.fileOpens.length; i++) {
+                    let OpenFileResponse = await msgController.loadFile(assertItem.fileOpens[i]);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                    msgController.setChannels(assertItem.setImageChannels[i]);
+                    let RasterTileData = await Stream(CARTA.RasterTileData,3);
+                }
+            });
+
+            assertItem.rasterTileDatas.map((rasterTileData: CARTA.IRasterTileData, index: number) => {
+                const { requiredTiles, ..._channel } = assertItem.changeImageChannels[index];
+                describe(`Set Image Channel ${JSON.stringify(_channel)}`, () => {
+                    let lastRegionHistogramData: CARTA.RegionHistogramData[] = []; 
+                    let RasterTileDataResponse: any = [];
+                    if (rasterTileData.fileId < 0) {
+                        test(`REGION_HISTOGRAM_DATA should not arrive within ${messageReturnTimeout * .5} ms.`, async () => {
+                            msgController.setChannels(assertItem.changeImageChannels[index]);
+                            let ErrorDataResponse = await Stream(CARTA.ErrorData,1);
+                        }, changeChannelTimeout + messageReturnTimeout);
+                    } else {
+                        test(`REGION_HISTOGRAM_DATA should arrive within ${changeChannelTimeout} ms.`, async () => {
+                            msgController.setChannels(assertItem.changeImageChannels[index]);
+                            msgController.histogramStream.pipe(take(1)).subscribe({
+                                next: (data) => {
+                                    lastRegionHistogramData.push(data)
+                                }
+                            });
+                            RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                        });
+
+                        test(`REGION_HISTOGRAM_DATA.file_id = ${assertItem.regionHistogramDatas[index].regionId}`, () => {
+                            expect(lastRegionHistogramData[0].regionId).toEqual(assertItem.regionHistogramDatas[index].regionId);
+                        });
+    
+                        test(`REGION_HISTOGRAM_DATA.stokes = ${assertItem.regionHistogramDatas[index].stokes}`, () => {
+                            expect(lastRegionHistogramData[0].stokes).toEqual(assertItem.regionHistogramDatas[index].stokes);
+                        });
+    
+                        test(`REGION_HISTOGRAM_DATA.region_id = ${assertItem.regionHistogramDatas[index].regionId}`, () => {
+                            expect(lastRegionHistogramData[0].regionId).toEqual(assertItem.regionHistogramDatas[index].regionId);
+                        });
+    
+                        test(`REGION_HISTOGRAM_DATA.progress = ${assertItem.regionHistogramDatas[index].progress}`, () => {
+                            expect(lastRegionHistogramData[0].progress).toEqual(assertItem.regionHistogramDatas[index].progress);
+                        });
+    
+                        test(`REGION_HISTOGRAM_DATA.histograms.channel = ${assertItem.regionHistogramDatas[index].channel}`, () => {
+                            expect(lastRegionHistogramData[0].channel).toEqual(assertItem.regionHistogramDatas[index].channel);
+                        });
+
+                        test(`RASTER_IMAGE_DATA should arrive within ${changeChannelTimeout} ms.`, async () => {
+                            expect(RasterTileDataResponse.length).toEqual(3);
+                        }, changeChannelTimeout);
+    
+                        test(`RASTER_IMAGE_DATA.file_id = ${rasterTileData.fileId}`, () => {
+                            expect(RasterTileDataResponse[1].fileId).toEqual(rasterTileData.fileId);
+                        });
+    
+                        test(`RASTER_IMAGE_DATA.channel = ${rasterTileData.channel}`, () => {
+                            expect(RasterTileDataResponse[1].channel).toEqual(rasterTileData.channel);
+                        });
+    
+                        test(`RASTER_IMAGE_DATA.stokes = ${rasterTileData.stokes}`, () => {
+                            expect(RasterTileDataResponse[1].stokes).toEqual(rasterTileData.stokes);
+                        });
+                    }
+                });
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/CASA_REGION_EXPORT.test.ts
+++ b/src/test/CASA_REGION_EXPORT.test.ts
@@ -6,6 +6,7 @@ import config from "./config.json";
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let regionSubdirectory = config.path.region;
+let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 let exportTimeout = config.timeout.export;
@@ -309,7 +310,7 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
             });
 
             assertItem.exportRegionAck.map((exRegion, idxRegion) => {
-                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
                     let exportRegionAck: any;
                     test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                         let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
@@ -329,7 +330,7 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
                         regionStyle.set(15, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
                         regionStyle.set(16, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
 
-                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        assertItem.exportRegion[idxRegion].directory = saveSubdirectory; 
                         exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
                     }, exportTimeout);
     
@@ -344,11 +345,11 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
             });
 
             assertItem.importRegionAck.map((Region, idxRegion) => {
-                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}" from ${saveSubdirectory}`, () => {
                     let importRegionAck: any;
                     let importRegionAckProperties: any;
                     test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        assertItem.importRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        assertItem.importRegion[idxRegion].directory = saveSubdirectory; 
                         importRegionAck = await msgController.importRegion(assertItem.importRegion[idxRegion].directory, assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId)
                         importRegionAckProperties = Object.keys(importRegionAck.regions)
                     }, importTimeout);

--- a/src/test/CASA_REGION_EXPORT.test.ts
+++ b/src/test/CASA_REGION_EXPORT.test.ts
@@ -1,0 +1,373 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+let exportTimeout = config.timeout.export;
+
+interface ImportRegionAckExt extends CARTA.IImportRegionAck {
+    lengthOfRegions?: number;
+    assertRegionId?: {
+        index: number,
+        id: number,
+    };
+};
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    precisionDigits: number;
+    setRegion: CARTA.ISetRegion[];
+    exportRegion: CARTA.IExportRegion[];
+    exportRegionAck: CARTA.IExportRegionAck[];
+    importRegion: CARTA.IImportRegion[];
+    importRegionAck: ImportRegionAckExt[];
+};
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    precisionDigits: 4,
+    setRegion:
+        [
+            {
+                fileId: 0,
+                regionId: -1,   // 1
+                regionInfo: {
+                    regionType: CARTA.RegionType.POINT,
+                    rotation: 0,
+                    controlPoints: [{ x: -109.579, y: 618.563 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 2
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: -114.748, y: 508.708 }, { x: 90.468, y: 90.468 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 3
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: -114.748, y: 332.941 }, { x: 170.597, y: 64.620 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 4
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                    controlPoints: [{ x: -126.380, y: 167.512 }, { x: 149.919, y: 38.772 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 5
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 758.918, y: 634.071 }, { x: 62.035, y: 62.035 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 6
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 751.163, y: 444.088 }, { x: 29.725, y: 93.053 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 7
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                    controlPoints: [{ x: 749.871, y: 290.291 }, { x: 25.848, y: 84.006 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 8
+                regionInfo: {
+                    regionType: CARTA.RegionType.POLYGON,
+                    rotation: 0,
+                    controlPoints: [{ x: 757.626, y: 184.314 }, { x: 698.175, y: 66.7051 }, { x: 831.293, y: 106.769 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 9
+                regionInfo: {
+                    regionType: CARTA.RegionType.POINT,
+                    rotation: 0,
+                    controlPoints: [{ x: 199.306, y: 565.574 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 10
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: 192.844, y: 473.813 }, { x: 67.205, y: 67.205 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 11
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: 174.750, y: 360.081 }, { x: 118.901, y: 46.526 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 12
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                    controlPoints: [{ x: 204.475, y: 254.104 }, { x: 121.486, y: 46.526 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 13
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 415.138, y: 553.942 }, { x: 45.234, y: 45.234 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 14
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 406.091, y: 423.409 }, { x: 20.678, y: 68.497 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 15
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                    controlPoints: [{ x: 399.629, y: 331.648 }, { x: 19.386, y: 71.082 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 16
+                regionInfo: {
+                    regionType: CARTA.RegionType.POLYGON,
+                    rotation: 0,
+                    controlPoints: [{ x: 416.430, y: 229.548 }, { x: 335.008, y: 92.553 }, { x: 513.361, y: 135.202 }],
+                },
+            },
+        ],
+    exportRegion:
+        [
+            {
+                coordType: CARTA.CoordinateType.WORLD,
+                file: "M17_SWex_handMadeRegions_world.crtf",
+                fileId: 0,
+                type: CARTA.FileType.CRTF,
+                regionStyles: {
+                    // '1': { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] },
+                    // '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '9': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '10': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '11': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '12': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '13': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '14': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '15': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '16': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                },
+            },
+            {
+                coordType: CARTA.CoordinateType.PIXEL,
+                file: "M17_SWex_handMadeRegions_pix.crtf",
+                fileId: 0,
+                type: CARTA.FileType.CRTF,
+                regionStyles: {
+                    // '1': { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] },
+                    // '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '9': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '10': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '11': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '12': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '13': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '14': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '15': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '16': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                },
+            },
+        ],
+    exportRegionAck:
+        [
+            {
+                success: true,
+                contents: [],
+            },
+            {
+                success: true,
+                contents: [],
+            },
+        ],
+    importRegion:
+        [
+            {
+                contents: [],
+                file: "M17_SWex_handMadeRegions_world.crtf",
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+            },
+            {
+                contents: [],
+                file: "M17_SWex_handMadeRegions_pix.crtf",
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+            },
+        ],
+    importRegionAck:
+        [
+            {
+                success: true,
+                lengthOfRegions: 16,
+                assertRegionId: {
+                    index: 15,
+                    id: 32,
+                },
+            },
+            {
+                success: true,
+                lengthOfRegions: 16,
+                assertRegionId: {
+                    index: 15,
+                    id: 48,
+                },
+            },
+        ],
+};
+
+let basepath: string;
+describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file} and set regions"`, () => {
+            test(`Preparation: Open image and set regions`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                for (let region of assertItem.setRegion) {
+                    let RegionAckResponse = await msgController.setRegion(region.fileId, region.regionId, region.regionInfo);
+                    expect(RegionAckResponse.success).toBe(true);
+                }
+            });
+
+            assertItem.exportRegionAck.map((exRegion, idxRegion) => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                    let exportRegionAck: any;
+                    test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(2, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(3, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(4, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(5, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(6, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(7, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(8, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(9, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(10, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(11, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(12, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(13, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(14, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(15, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(16, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+
+                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
+                    }, exportTimeout);
+    
+                    test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
+                        expect(exportRegionAck.success).toBe(exRegion.success);
+                    });
+    
+                    test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
+                        expect(exportRegionAck.contents).toEqual(exRegion.contents);
+                    });
+                });
+            });
+
+            assertItem.importRegionAck.map((Region, idxRegion) => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    let importRegionAckProperties: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        assertItem.importRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        importRegionAck = await msgController.importRegion(assertItem.importRegion[idxRegion].directory, assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId)
+                        importRegionAckProperties = Object.keys(importRegionAck.regions)
+                    }, importTimeout);
+    
+                    test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
+                        expect(importRegionAck.success).toBe(Region.success);
+                    });
+    
+                    test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
+                        expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
+                    });
+    
+                    test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
+                        expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
+                    });
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
@@ -1,0 +1,91 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    precisionDigits: number;
+    importRegion: CARTA.IImportRegion[];
+    importRegionAck: CARTA.IImportRegionAck[];
+};
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    precisionDigits: 4,
+    importRegion:
+        [
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_regionSet2_pix.crtf",
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+            },
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_regionSet2_world.crtf",
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+            },
+        ],
+    importRegionAck:
+        [
+            { message: "Mixed world and pixel coordinates not supported" },
+            { message: "Mixed world and pixel coordinates not supported" },
+        ],
+};
+
+let basepath: string;
+describe("CASA_REGION_IMPORT_EXCEPTION: Testing import/export of CASA region format", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            });
+
+            assertItem.importRegionAck.map((regionAck, idxRegion) => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms and check the returned error message`, async () => {
+                        try {
+                            importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory, assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId);
+                        } catch (err) {
+                            expect(err).toContain(assertItem.importRegionAck[idxRegion].message);
+                        }
+                    }, importTimeout);
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -1,0 +1,313 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+let exportTimeout = config.timeout.export;
+
+interface ImportRegionAckExt2 extends CARTA.IImportRegionAck {
+    lengthOfRegions?: number;
+    assertRegionId?: {
+        index: number,
+        id: number,
+    };
+};
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesRequire: CARTA.IAddRequiredTiles;
+    precisionDigits: number;
+    importRegion: CARTA.IImportRegion;
+    importRegionAck: CARTA.IImportRegionAck;
+    exportRegion: CARTA.IExportRegion[];
+    exportRegionAck: CARTA.IExportRegionAck[];
+    importRegion2: CARTA.IImportRegion[];
+    importRegionAck2: ImportRegionAckExt2[];
+};
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+    },
+    addTilesRequire:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    precisionDigits: 4,
+    importRegion:
+    {
+        contents: [],
+        // directory: regionSubdirectory,
+        file: "M17_SWex_testRegions_pix.crtf",
+        groupId: 0,
+        type: CARTA.FileType.CRTF,
+    },
+    importRegionAck:
+    {
+        success: true,
+        regions: {
+            '1': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 40, y: 100 }],
+                regionType: CARTA.RegionType.RECTANGLE,
+            },
+            '2': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 40 }],
+                regionType: CARTA.RegionType.RECTANGLE,
+            },
+            '3': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 40 }],
+                rotation: 45,
+                regionType: CARTA.RegionType.RECTANGLE,
+            },
+            '4': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 600 }, { x: 400, y: 400 }],
+                regionType: CARTA.RegionType.POLYGON,
+            },
+            '5': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 200, y: 200 }],
+                regionType: CARTA.RegionType.ELLIPSE,
+            },
+            '6': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 100, y: 20 }],
+                regionType: CARTA.RegionType.ELLIPSE,
+                rotation: 45,
+            },
+            '7': {
+                controlPoints: [{ x: 320, y: 400 }, { x: 320, y: 300 }],
+                regionType: CARTA.RegionType.LINE,
+            },
+            '8': {
+                controlPoints: [{ x: 320, y: 300 }],
+                regionType: CARTA.RegionType.POINT,
+            },
+        },
+        regionStyles: {
+            '1': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '2': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '3': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '4': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '5': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '6': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '7': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '8': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+        },
+    },
+    exportRegion:
+        [
+            {
+                coordType: CARTA.CoordinateType.WORLD,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_world.crtf",
+                fileId: 0,
+                type: CARTA.FileType.CRTF,
+                regionStyles: {
+                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                },
+            },
+            {
+                coordType: CARTA.CoordinateType.PIXEL,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_pix.crtf",
+                fileId: 0,
+                type: CARTA.FileType.CRTF,
+                regionStyles: {
+                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                }
+            },
+        ],
+    exportRegionAck:
+        [
+            {
+                success: true,
+                contents: [],
+            },
+            {
+                success: true,
+                contents: [],
+            },
+        ],
+    importRegion2:
+        [
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_world.crtf",
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+            },
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_pix.crtf",
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+            },
+        ],
+    importRegionAck2:
+        [
+            {
+                success: true,
+                lengthOfRegions: 8,
+                assertRegionId: {
+                    index: 7,
+                    id: 16,
+                },
+            },
+            {
+                success: true,
+                lengthOfRegions: 8,
+                assertRegionId: {
+                    index: 7,
+                    id: 24,
+                },
+            },
+        ],
+};
+
+let basepath: string;
+describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesRequire);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            describe(`Import "${assertItem.importRegion.file}"`, () => {
+                let importRegionAck: any;
+                let importRegionAckProperties: any[];
+                test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                    importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId )
+                    importRegionAckProperties = Object.keys(importRegionAck.regions);
+                    if (importRegionAck.message != '') {
+                        console.warn(importRegionAck.message);
+                    }
+                }, importTimeout);
+    
+                test(`IMPORT_REGION_ACK.success = ${assertItem.importRegionAck.success}`, () => {
+                    expect(importRegionAck.success).toBe(assertItem.importRegionAck.success);
+                });
+    
+                test(`Length of IMPORT_REGION_ACK.region = ${Object.keys(assertItem.importRegionAck.regions).length}`, () => {
+                    expect(importRegionAckProperties.length).toEqual(Object.keys(assertItem.importRegionAck.regions).length);
+                });
+    
+                Object.keys(assertItem.importRegionAck.regions).map((region, index) => {
+                    test(`IMPORT_REGION_ACK.region[${index}] = "Id:${region}, Type:${CARTA.RegionType[assertItem.importRegionAck.regions[region].regionType]}"`, () => {
+                        expect(importRegionAckProperties[index]).toEqual(String(region));
+                        expect(importRegionAck.regions[importRegionAckProperties[index]].regionType).toEqual(assertItem.importRegionAck.regions[region].regionType);
+                        if (assertItem.importRegionAck.regions[region].rotation)
+                            expect(importRegionAck.regions[importRegionAckProperties[index]].rotation).toEqual(assertItem.importRegionAck.regions[region].rotation);
+                        expect(importRegionAck.regions[importRegionAckProperties[index]].controlPoints).toEqual(assertItem.importRegionAck.regions[region].controlPoints);
+                    });
+                });
+            });
+
+            assertItem.exportRegionAck.map((exRegion, idxRegion) => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                    let exportRegionAck: any;
+                    test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(2, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(3, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(4, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(5, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+
+                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
+                    }, exportTimeout);
+    
+                    test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
+                        expect(exportRegionAck.success).toBe(exRegion.success);
+                    });
+    
+                    test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
+                        expect(exportRegionAck.contents).toEqual(exRegion.contents);
+                    });
+                });
+            });
+
+            assertItem.importRegionAck2.map((Region, idxRegion) => {
+                describe(`Import "${assertItem.importRegion2[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    let importRegionAckProperties: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
+                        
+                        importRegionAckProperties = Object.keys(importRegionAck.regions);
+                        if (importRegionAck.message != '') {
+                            console.warn(importRegionAck.message);
+                        }
+                    }, importTimeout);
+    
+                    test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
+                        expect(importRegionAck.success).toBe(Region.success);
+                    });
+    
+                    test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
+                        expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
+                    });
+    
+                    test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
+                        expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
+                    });
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -6,6 +6,7 @@ import config from "./config.json";
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let regionSubdirectory = config.path.region;
+let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 let exportTimeout = config.timeout.export;
@@ -54,7 +55,6 @@ let assertItem: AssertItem = {
     importRegion:
     {
         contents: [],
-        // directory: regionSubdirectory,
         file: "M17_SWex_testRegions_pix.crtf",
         groupId: 0,
         type: CARTA.FileType.CRTF,
@@ -113,7 +113,6 @@ let assertItem: AssertItem = {
         [
             {
                 coordType: CARTA.CoordinateType.WORLD,
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.crtf",
                 fileId: 0,
                 type: CARTA.FileType.CRTF,
@@ -130,7 +129,6 @@ let assertItem: AssertItem = {
             },
             {
                 coordType: CARTA.CoordinateType.PIXEL,
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.crtf",
                 fileId: 0,
                 type: CARTA.FileType.CRTF,
@@ -161,14 +159,12 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.crtf",
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
             },
             {
                 contents: [],
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.crtf",
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
@@ -254,7 +250,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             });
 
             assertItem.exportRegionAck.map((exRegion, idxRegion) => {
-                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file} to ${saveSubdirectory}"`, () => {
                     let exportRegionAck: any;
                     test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                         let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
@@ -266,8 +262,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                         regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
                         regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
-                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
-                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
+                        exportRegionAck = await msgController.exportRegion(saveSubdirectory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
                     }, exportTimeout);
     
                     test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
@@ -281,11 +276,11 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             });
 
             assertItem.importRegionAck2.map((Region, idxRegion) => {
-                describe(`Import "${assertItem.importRegion2[idxRegion].file}"`, () => {
+                describe(`Import "${assertItem.importRegion2[idxRegion].file}" from ${saveSubdirectory}`, () => {
                     let importRegionAck: any;
                     let importRegionAckProperties: any;
                     test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
+                        importRegionAck = await msgController.importRegion(saveSubdirectory,assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
                         
                         importRegionAckProperties = Object.keys(importRegionAck.regions);
                         if (importRegionAck.message != '') {

--- a/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
@@ -1,0 +1,290 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesRequire: CARTA.IAddRequiredTiles;
+    precisionDigits: number;
+    importRegion: CARTA.IImportRegion[];
+    importRegionAck: CARTA.IImportRegionAck[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+    },
+    addTilesRequire:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    precisionDigits: 1,
+    importRegion:
+        [
+            {
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_regionSet1_world.crtf",
+            },
+            {
+                groupId: 0,
+                type: CARTA.FileType.CRTF,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_regionSet1_pix.crtf",
+            },
+        ],
+    importRegionAck: [
+        {
+            success: true,
+            regions: {
+                '1': {
+                    controlPoints: [{ x: -103.80, y: 613.10 }],
+                    regionType: CARTA.RegionType.POINT,
+                    rotation: 0,
+                },
+                '2': {
+                    controlPoints: [{ x: -106.40, y: 528.9 }, { x: 75.10, y: 75.10 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '3': {
+                    controlPoints: [{ x: -118.00, y: 412.40 }, { x: 137.20, y: 54.40 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '4': {
+                    controlPoints: [{ x: -120.60, y: 251.90 }, { x: 173.50, y: 44.00 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                },
+                '5': {
+                    controlPoints: [{ x: 758.30, y: 635.10 }, { x: 50.50, y: 50.50 }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '6': {
+                    controlPoints: [{ x: 749.30, y: 486.20 }, { x: 29.80, y: 69.90, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '7': {
+                    controlPoints: [{ x: 745.40, y: 369.70 }, { x: 18.10, y: 79.00, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                },
+                '8': {
+                    controlPoints: [{ x: 757.00, y: 270.10 }, { x: 715.60, y: 118.60 }, { x: 829.50, y: 191.10 }],
+                    regionType: CARTA.RegionType.POLYGON,
+                },
+                '9': {
+                    controlPoints: [{ x: 175.80, y: 591.10 }],
+                    regionType: CARTA.RegionType.POINT,
+                },
+                '10': {
+                    controlPoints: [{ x: 168.00, y: 519.90 }, { x: 57.00, y: 57.00 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '11': {
+                    controlPoints: [{ x: 130.50, y: 429.30 }, { x: 121.70, y: 36.208 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '12': {
+                    controlPoints: [{ x: 100.70, y: 284.30 }, { x: 137.20, y: 36.20 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                },
+                '13': {
+                    controlPoints: [{ x: 496.80, y: 574.30 }, { x: 49.20, y: 49.20 }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '14': {
+                    controlPoints: [{ x: 533.10, y: 435.70 }, { x: 25.90, y: 69.90, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '15': {
+                    controlPoints: [{ x: 522.70, y: 307.60 }, { x: 22.00, y: 80.30, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                },
+                '16': {
+                    controlPoints: [{ x: 491.60, y: 228.60 }, { x: 416.50, y: 110.80 }, { x: 586.10, y: 106.90 }],
+                    regionType: CARTA.RegionType.POLYGON,
+                },
+            },
+        },
+        {
+            success: true,
+            regions: {
+                '17': {
+                    controlPoints: [{ x: -103.80, y: 613.10 }],
+                    regionType: CARTA.RegionType.POINT,
+                    rotation: 0,
+                },
+                '18': {
+                    controlPoints: [{ x: -106.40, y: 528.9 }, { x: 75.10, y: 75.10 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '19': {
+                    controlPoints: [{ x: -118.00, y: 412.40 }, { x: 137.20, y: 54.40 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '20': {
+                    controlPoints: [{ x: -120.6, y: 251.9 }, { x: 173.5, y: 44.0 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                },
+                '21': {
+                    controlPoints: [{ x: 758.30, y: 635.10 }, { x: 50.50, y: 50.50 }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '22': {
+                    controlPoints: [{ x: 749.30, y: 486.20 }, { x: 29.80, y: 69.90, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '23': {
+                    controlPoints: [{ x: 745.40, y: 369.70 }, { x: 18.10, y: 79.00, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                },
+                '24': {
+                    controlPoints: [{ x: 757.00, y: 270.10 }, { x: 715.60, y: 118.60 }, { x: 829.50, y: 191.10 }],
+                    regionType: CARTA.RegionType.POLYGON,
+                },
+                '25': {
+                    controlPoints: [{ x: 175.80, y: 591.10 }],
+                    regionType: CARTA.RegionType.POINT,
+                },
+                '26': {
+                    controlPoints: [{ x: 168.00, y: 519.90 }, { x: 57.00, y: 57.00 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '27': {
+                    controlPoints: [{ x: 130.50, y: 429.30 }, { x: 121.70, y: 36.208 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                },
+                '28': {
+                    controlPoints: [{ x: 100.70, y: 284.30 }, { x: 137.20, y: 36.20 }],
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                },
+                '29': {
+                    controlPoints: [{ x: 496.80, y: 574.30 }, { x: 49.20, y: 49.20 }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '30': {
+                    controlPoints: [{ x: 533.10, y: 435.70 }, { x: 25.90, y: 69.90, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                },
+                '31': {
+                    controlPoints: [{ x: 522.70, y: 307.60 }, { x: 22.00, y: 80.30, }],
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                },
+                '32': {
+                    controlPoints: [{ x: 491.60, y: 228.60 }, { x: 416.50, y: 110.80 }, { x: 586.10, y: 106.90 }],
+                    regionType: CARTA.RegionType.POLYGON,
+                },
+            },
+        },
+    ],
+};
+
+let basepath: string;
+describe("CASA_REGION_IMPORT_INTERNAL: Testing import of CASA region files made with CARTA", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            });
+
+            assertItem.importRegionAck.map((regionAck, idxRegion) => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    let importRegionAckProperties: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId )
+                        importRegionAckProperties = Object.keys(importRegionAck.regions)
+                    }, importTimeout);
+    
+                    test(`IMPORT_REGION_ACK.success = ${regionAck.success}`, () => {
+                        expect(importRegionAck.success).toBe(regionAck.success);
+                    });
+    
+                    test(`Length of IMPORT_REGION_ACK.region = ${Object.keys(regionAck.regions).length}`, () => {
+                        expect(importRegionAckProperties.length).toEqual(Object.keys(regionAck.regions).length);
+                    });
+    
+                    Object.keys(regionAck.regions).map((region, index) => {
+                        test(`IMPORT_REGION_ACK.region[${index}] = "Id:${region}, Type:${CARTA.RegionType[regionAck.regions[region].regionType]}"`, () => {
+                            expect(importRegionAckProperties[index]).toEqual(String(region));
+                            expect(importRegionAck.regions[importRegionAckProperties[index]].regionType).toEqual(regionAck.regions[region].regionType);
+                            if (regionAck.regions[region].rotation) {
+                                expect(importRegionAck.regions[importRegionAckProperties[index]].rotation).toBeCloseTo(regionAck.regions[region].rotation);
+                            };
+                            importRegionAck.regions[importRegionAckProperties[index]].controlPoints.map((point, idx) => {
+                                expect(point.x).toBeCloseTo(regionAck.regions[region].controlPoints[idx].x, assertItem.precisionDigits);
+                                expect(point.y).toBeCloseTo(regionAck.regions[region].controlPoints[idx].y, assertItem.precisionDigits);
+                            });
+                        });
+                    });
+    
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CASA_REGION_INFO.test.ts
+++ b/src/test/CASA_REGION_INFO.test.ts
@@ -138,6 +138,9 @@ describe("CASA_REGION_INFO: Testing CASA region list and info", () => {
             let fileListResponse = await msgController.getFileList("$BASE",0);
             basepath = fileListResponse.directory;
             assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+            assertItem.regionListRequest.directory = basepath + "/" + assertItem.regionListRequest.directory;
+            assertItem.regionFileInfoRequest[0].directory = basepath + "/" + assertItem.regionFileInfoRequest[0].directory;
+            assertItem.regionFileInfoRequest[1].directory = basepath + "/" + assertItem.regionFileInfoRequest[1].directory;
         });
 
         describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
@@ -159,7 +162,7 @@ describe("CASA_REGION_INFO: Testing CASA region list and info", () => {
                 });
     
                 test(`REGION_LIST_RESPONSE.directory = ${assertItem.regionListResponse.directory}`, () => {
-                    expect(regionListResponse.directory).toEqual(assertItem.regionListResponse.directory);
+                    expect(regionListResponse.directory).toContain(assertItem.regionListResponse.directory);
                 });
     
                 test(`REGION_LIST_RESPONSE.parent is /${assertItem.regionListResponse.parent}`, () => {

--- a/src/test/CASA_REGION_INFO.test.ts
+++ b/src/test/CASA_REGION_INFO.test.ts
@@ -1,0 +1,213 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let listTimeout = config.timeout.listFile;
+let readTimeout = config.timeout.readFile;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    precisionDigits: number;
+    regionListRequest: CARTA.IRegionListRequest;
+    regionListResponse: CARTA.IRegionListResponse;
+    regionFileInfoRequest: CARTA.IRegionFileInfoRequest[];
+    regionFileInfoResponse: CARTA.IRegionFileInfoResponse[];
+};
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    precisionDigits: 4,
+    regionListRequest:
+    {
+        directory: regionSubdirectory,
+    },
+    regionListResponse:
+    {
+        success: true,
+        directory: regionSubdirectory,
+        parent: testSubdirectory,
+        subdirectories: [],
+        files: [
+            {
+                name: "M17_SWex_regionSet1_pix.crtf",
+                type: CARTA.FileType.CRTF,
+            },
+            {
+                name: "M17_SWex_regionSet1_world.crtf",
+                type: CARTA.FileType.CRTF,
+            },
+        ],
+    },
+    regionFileInfoRequest:
+        [
+            {
+                directory: regionSubdirectory,
+                file: "M17_SWex_regionSet1_world.crtf",
+            },
+            {
+                directory: regionSubdirectory,
+                file: "M17_SWex_regionSet1_pix.crtf",
+            },
+        ],
+    regionFileInfoResponse:
+        [
+            {
+                success: true,
+                fileInfo: {
+                    name: "M17_SWex_regionSet1_world.crtf",
+                    type: CARTA.FileType.CRTF,
+                },
+                contents: [
+                    "#CRTFv0 CASA Region Text Format version 0",
+                    "symbol [[275.13653085deg, -16.17909524deg], .] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[275.13683271deg, -16.18844433deg], [30.0324arcsec, 30.0324arcsec]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[275.13818398deg, -16.20138900deg], [54.8867arcsec, 21.7476arcsec]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "rotbox [[275.13848816deg, -16.21922423deg], [69.3851arcsec, 17.6052arcsec], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[275.03678830deg, -16.17664969deg], [20.1942arcsec, 20.1942arcsec], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[275.03783248deg, -16.19319074deg], [11.9094arcsec, 27.9612arcsec], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[275.03827857deg, -16.20613583deg], [7.2492arcsec, 31.5858arcsec], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "poly [[275.03692766deg, -16.21721067deg], [275.04171714deg, -16.23404023deg], [275.02853660deg, -16.22598234deg]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "symbol [[275.10418191deg, -16.18154538deg], .] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[275.10508122deg, -16.18945613deg], [22.7832arcsec, 22.7832arcsec]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[275.10942574deg, -16.19952405deg], [48.6731arcsec, 14.4984arcsec]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "rotbox [[275.11287275deg, -16.21563298deg], [54.8867arcsec, 14.4984arcsec], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[275.06703966deg, -16.18341488deg], [19.6764arcsec, 19.6764arcsec], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[275.06284424deg, -16.19880459deg], [10.3560arcsec, 27.9612arcsec], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[275.06404078deg, -16.21304420deg], [8.8026arcsec, 32.1036arcsec], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "poly [[275.06764385deg, -16.22182373deg], [275.07633134deg, -16.23491317deg], [275.05670656deg, -16.23534275deg]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "",
+                ],
+            },
+            {
+                success: true,
+                fileInfo: {
+                    name: "M17_SWex_regionSet1_pix.crtf",
+                    type: CARTA.FileType.CRTF,
+                },
+                contents: [
+                    "#CRTFv0 CASA Region Text Format version 0",
+                    "symbol [[-103.8pix, 613.1pix], .] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[-106.4pix, 528.9pix], [75.1pix, 75.1pix]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[-118.0pix, 412.4pix], [137.2pix, 54.4pix]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "rotbox [[-120.6pix, 251.9pix], [173.5pix, 44.0pix], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[758.3pix, 635.1pix], [50.5pix, 50.5pix], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[749.3pix, 486.2pix], [29.8pix, 69.9pix], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[745.4pix, 369.7pix], [18.1pix, 79.0pix], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "poly [[757.0pix, 270.1pix], [715.6pix, 118.6pix], [829.5pix, 191.1pix]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "symbol [[175.8pix, 591.1pix], .] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[168.0pix, 519.9pix], [57.0pix, 57.0pix]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "centerbox [[130.5pix, 429.3pix], [121.7pix, 36.2pix]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "rotbox [[100.7pix, 284.3pix], [137.2pix, 36.2pix], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[496.8pix, 574.3pix], [49.2pix, 49.2pix], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[533.1pix, 435.7pix], [25.9pix, 69.9pix], 0.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "ellipse [[522.7pix, 307.6pix], [22.0pix, 80.3pix], 45.00000000deg] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "poly [[491.6pix, 228.6pix], [416.5pix, 110.8pix], [586.1pix, 106.9pix]] coord=ICRS, corr=[I], linewidth=1, linestyle=-, symsize=1, symthick=1, color=green, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false",
+                    "",
+                ],
+            },
+        ],
+};
+
+let basepath: string;
+describe("CASA_REGION_INFO: Testing CASA region list and info", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            });
+
+            describe(`Go to "${regionSubdirectory}" and send REGION_LIST_REQUEST`, () => {
+                let regionListResponse: any;
+                test(`REGION_LIST_RESPONSE should return within ${listTimeout}ms`, async () => {
+                    regionListResponse = await msgController.getRegionList(assertItem.regionListRequest.directory, assertItem.regionListRequest.filterMode);
+                }, listTimeout);
+
+                test(`REGION_LIST_RESPONSE.success = ${assertItem.regionListResponse.success}`, () => {
+                    expect(regionListResponse.success).toBe(assertItem.regionListResponse.success);
+                });
+    
+                test(`REGION_LIST_RESPONSE.directory = ${assertItem.regionListResponse.directory}`, () => {
+                    expect(regionListResponse.directory).toEqual(assertItem.regionListResponse.directory);
+                });
+    
+                test(`REGION_LIST_RESPONSE.parent is /${assertItem.regionListResponse.parent}`, () => {
+                    expect(regionListResponse.parent).toMatch(new RegExp(`${regionListResponse.parent}$`));
+                });
+    
+                test(`REGION_LIST_RESPONSE.subdirectories = ${JSON.stringify(assertItem.regionListResponse.subdirectories)}`, () => {
+                    expect(regionListResponse.subdirectories).toEqual(assertItem.regionListResponse.subdirectories);
+                });
+    
+                assertItem.regionListResponse.files.map(file => {
+                    test(`REGION_LIST_RESPONSE.file should contain "${file.name}" in type of ${CARTA.FileType[file.type]}`, () => {
+                        expect(regionListResponse.files.find(f => f.name == file.name).type).toEqual(file.type);
+                    });
+                });
+            });
+        });
+
+        assertItem.regionFileInfoResponse.map((fileInfo, idxInfo) => {
+            describe(`Read "${assertItem.regionFileInfoRequest[idxInfo].file}"`, () => {
+                let regionFileInfoResponse: any;
+                test(`REGION_FILE_INFO_RESPONSE should return within ${readTimeout}ms`, async () => {
+                    regionFileInfoResponse = await msgController.getRegionFileInfo(assertItem.regionFileInfoRequest[idxInfo].directory, assertItem.regionFileInfoRequest[idxInfo].file)
+                }, readTimeout);
+
+                test(`REGION_FILE_INFO_RESPONSE.success = ${fileInfo.success}`, () => {
+                    expect(regionFileInfoResponse.success).toBe(fileInfo.success);
+                });
+
+                test(`REGION_FILE_INFO_RESPONSE.fileinfo.name = "${fileInfo.fileInfo.name}"`, () => {
+                    expect(regionFileInfoResponse.fileInfo.name).toEqual(fileInfo.fileInfo.name);
+                });
+
+                test(`REGION_FILE_INFO_RESPONSE.fileinfo.type = ${CARTA.FileType[fileInfo.fileInfo.type]}`, () => {
+                    expect(regionFileInfoResponse.fileInfo.type).toEqual(fileInfo.fileInfo.type);
+                });
+
+                test(`Length of REGION_FILE_INFO_RESPONSE.contents = ${fileInfo.contents.length}`, () => {
+                    expect(regionFileInfoResponse.contents.length).toEqual(fileInfo.contents.length);
+                });
+
+                fileInfo.contents.map((message, index) => {
+                    test(`REGION_FILE_INFO_RESPONSE.contents[${index}] = "${message.slice(0, 45)}${message.length < 45 ? "" : "..."}"`, () => {
+                        expect(regionFileInfoResponse.contents[index]).toEqual(message);
+                    });
+                });
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CATALOG_GENERAL.test.ts
+++ b/src/test/CATALOG_GENERAL.test.ts
@@ -1,0 +1,320 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.catalogArtificial;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile
+
+interface ICatalogFileInfoResponseExt extends CARTA.ICatalogFileInfoResponse {
+    lengthOfHeaders: number;
+};
+
+interface IOpenCatalogFileAckExt extends CARTA.IOpenCatalogFileAck {
+    lengthOfHeaders: number;
+};
+
+interface ICatalogFilterResponseExt extends CARTA.ICatalogFilterResponse {
+    lengthOfColumns: number;
+    fileid: number;
+};
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setSpatialReq: CARTA.ISetSpatialRequirements;
+    catalogListReq: CARTA.ICatalogListRequest;
+    catalogListResponse: CARTA.ICatalogListResponse;
+    catalogFileInfoReq: CARTA.ICatalogFileInfoRequest;
+    catalogFileInfoResponse: ICatalogFileInfoResponseExt;
+    openCatalogFile: CARTA.IOpenCatalogFile;
+    openCatalogFileAck: IOpenCatalogFileAckExt;
+    catalogFilterReq: CARTA.ICatalogFilterRequest[];
+    catalogFilterResponse: ICatalogFilterResponseExt[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "Gaussian_J2000.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1250, y: 100 },
+    },
+    setSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}],
+    },
+    catalogListReq: {
+        directory:  testSubdirectory
+    },
+    catalogFileInfoReq: {
+        directory:  testSubdirectory,
+        name: "artificial_catalog_J2000.xml"
+    },
+    openCatalogFile: {
+        directory:  testSubdirectory,
+        fileId: 1,
+        name: "artificial_catalog_J2000.xml",
+        previewDataSize: 50
+    },
+    catalogFilterReq: [
+        {
+            columnIndices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            fileId: 1,
+            filterConfigs: null,
+            imageBounds: {},
+            regionId: null,
+            sortColumn: "RA_d",
+            sortingType: 0,
+            subsetDataSize: 29,
+            subsetStartIndex: 0
+        },
+        {
+            columnIndices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            fileId: 1,
+            filterConfigs: [
+                { columnName: "RA_d", comparisonOperator: 5, value: 160 }
+            ],
+            imageBounds: {
+                xColumnName: null,
+                yColumnName: null
+            },
+            regionId: null,
+            sortColumn: null,
+            sortingType: null,
+            subsetDataSize: 29,
+            subsetStartIndex: 0
+        },
+        {
+            columnIndices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            fileId: 1,
+            filterConfigs: [
+                { columnName: "OTYPE_S", subString: "Star" }
+            ],
+            imageBounds: {
+                xColumnName: null,
+                yColumnName: null
+            },
+            regionId: null,
+            sortColumn: null,
+            sortingType: null,
+            subsetDataSize: 29,
+            subsetStartIndex: 0
+        },
+        {
+            columnIndices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            fileId: 1,
+            filterConfigs: [
+                { columnName: "OTYPE_S", subString: "Star" },
+                { columnName: "RA_d", comparisonOperator: 5, value: 160 }
+            ],
+            imageBounds: {
+                xColumnName: null,
+                yColumnName: null
+            },
+            regionId: null,
+            sortColumn: "RA_d",
+            sortingType: 0,
+            subsetDataSize: 29,
+            subsetStartIndex: 0
+        },
+    ],
+    catalogListResponse: {
+        directory: testSubdirectory,
+        success: true,
+        subdirectories: ["Gaussian_J2000.image"]
+    },
+    catalogFileInfoResponse: {
+        fileInfo: { name: "artificial_catalog_J2000.xml", type: 1, fileSize: 113559 },
+        success: true,
+        lengthOfHeaders: 235,
+    },
+    openCatalogFileAck: {
+        dataSize: 29,
+        fileId: 1,
+        fileInfo: { name: "artificial_catalog_J2000.xml", type: 1, fileSize: 113559 },
+        lengthOfHeaders: 235,
+        success: true
+    },
+    catalogFilterResponse: [
+        {
+            lengthOfColumns: 10,
+            fileid: 1,
+            subsetDataSize: 29,
+            subsetEndIndex: 29,
+            filterDataSize: 29,
+            requestEndIndex: 29,
+            progress: 1
+        },
+        {
+            lengthOfColumns: 10,
+            fileid: 1,
+            subsetDataSize: 26,
+            subsetEndIndex: 26,
+            filterDataSize: 26,
+            requestEndIndex: 26,
+            progress: 1
+        },
+        {
+            lengthOfColumns: 10,
+            fileid: 1,
+            subsetDataSize: 24,
+            subsetEndIndex: 24,
+            filterDataSize: 24,
+            requestEndIndex: 24,
+            progress: 1
+        },
+        {
+            lengthOfColumns: 10,
+            fileid: 1,
+            subsetDataSize: 23,
+            subsetEndIndex: 23,
+            filterDataSize: 23,
+            requestEndIndex: 23,
+            progress: 1
+        },
+    ]
+};
+
+let basepath: string;
+describe("Test for general CATALOG related messages:", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.fileOpen.directory;
+            assertItem.catalogListReq.directory = basepath + "/" + assertItem.catalogListReq.directory;
+            assertItem.catalogFileInfoReq.directory = basepath + "/" + assertItem.catalogFileInfoReq.directory;
+            assertItem.openCatalogFile.directory = basepath + "/" + assertItem.openCatalogFile.directory;
+        });
+
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen.file);
+        }, openFileTimeout);
+
+        test(`(Step 2) return RASTER_TILE_DATA(Stream) and check total length | `, async () => {
+            msgController.addRequiredTiles(assertItem.addTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        test(`(Step 3) Request CatalogList & check CatalogListResponse | `, async () => {
+            let CatalogListAck = await msgController.getCatalogList(assertItem.catalogListReq.directory, assertItem.catalogListReq.filterMode);
+            expect(CatalogListAck.directory).toContain(assertItem.catalogListResponse.directory)
+            expect(CatalogListAck.success).toEqual(assertItem.catalogListResponse.success);
+            let CatalogListAckTempSubdirectories = CatalogListAck.subdirectories.map(f => f.name);
+            expect(CatalogListAckTempSubdirectories).toEqual(expect.arrayContaining(assertItem.catalogListResponse.subdirectories));
+        });
+
+        test(`(Step 4) Request CatalogFileInfo & check CatalogFileInfoAck | `, async () => {
+            let CatalogFileInfoAck = await msgController.getCatalogFileInfo(assertItem.catalogFileInfoReq.directory, assertItem.catalogFileInfoReq.name)
+            expect(CatalogFileInfoAck.success).toEqual(assertItem.catalogFileInfoResponse.success);
+            expect(CatalogFileInfoAck.fileInfo.name).toEqual(assertItem.catalogFileInfoResponse.fileInfo.name);
+            expect(CatalogFileInfoAck.fileInfo.type).toEqual(assertItem.catalogFileInfoResponse.fileInfo.type);
+            expect(CatalogFileInfoAck.fileInfo.fileSize.low).toEqual(assertItem.catalogFileInfoResponse.fileInfo.fileSize);
+            expect(CatalogFileInfoAck.headers.length).toEqual(assertItem.catalogFileInfoResponse.lengthOfHeaders);
+        });
+
+        test(`(Step 5) Request CatalogFile & check CatalogFileAck | `, async () => {
+            let CatalogFileAck = await msgController.loadCatalogFile(assertItem.openCatalogFile.directory, assertItem.openCatalogFile.name, assertItem.openCatalogFile.fileId, assertItem.openCatalogFile.previewDataSize)
+            expect(CatalogFileAck.success).toEqual(assertItem.openCatalogFileAck.success);
+            expect(CatalogFileAck.dataSize).toEqual(assertItem.openCatalogFileAck.dataSize);
+            expect(CatalogFileAck.fileId).toEqual(assertItem.openCatalogFileAck.fileId);
+            expect(CatalogFileAck.fileInfo.name).toEqual(assertItem.openCatalogFileAck.fileInfo.name);
+            expect(CatalogFileAck.fileInfo.type).toEqual(assertItem.openCatalogFileAck.fileInfo.type);
+            expect(CatalogFileAck.fileInfo.fileSize.low).toEqual(assertItem.openCatalogFileAck.fileInfo.fileSize);
+            expect(CatalogFileAck.headers.length).toEqual(assertItem.openCatalogFileAck.lengthOfHeaders);
+        });
+
+        test(`(Step 6) Request CatalogFilter: Sorting & check CatalogFilterResponse | `, async () => {
+            await msgController.setCatalogFilterRequest(assertItem.catalogFilterReq[0]);
+            let CatalogFilterResponse = await Stream(CARTA.CatalogFilterResponse, 1);
+            expect(Object.keys(CatalogFilterResponse[0].columns).length).toEqual(assertItem.catalogFilterResponse[0].lengthOfColumns);
+            expect(CatalogFilterResponse[0].fileid).toEqual(assertItem.catalogFilterResponse[0].fileId);
+            expect(CatalogFilterResponse[0].subsetDataSize).toEqual(assertItem.catalogFilterResponse[0].subsetDataSize);
+            expect(CatalogFilterResponse[0].subsetEndIndex).toEqual(assertItem.catalogFilterResponse[0].subsetEndIndex);
+            expect(CatalogFilterResponse[0].filterDataSize).toEqual(assertItem.catalogFilterResponse[0].filterDataSize);
+            expect(CatalogFilterResponse[0].requestEndIndex).toEqual(assertItem.catalogFilterResponse[0].requestEndIndex);
+            expect(CatalogFilterResponse[0].progress).toEqual(assertItem.catalogFilterResponse[0].progress);
+        });
+        
+        test(`(Step 7) Request CatalogFilter: Filter(number) & check CatalogFilterResponse | `, async () => {
+            await msgController.setCatalogFilterRequest(assertItem.catalogFilterReq[1]);
+            let CatalogFilterResponse2 = await Stream(CARTA.CatalogFilterResponse, 1);
+            expect(Object.keys(CatalogFilterResponse2[0].columns).length).toEqual(assertItem.catalogFilterResponse[1].lengthOfColumns);
+            expect(CatalogFilterResponse2[0].fileid).toEqual(assertItem.catalogFilterResponse[1].fileId);
+            expect(CatalogFilterResponse2[0].subsetDataSize).toEqual(assertItem.catalogFilterResponse[1].subsetDataSize);
+            expect(CatalogFilterResponse2[0].subsetEndIndex).toEqual(assertItem.catalogFilterResponse[1].subsetEndIndex);
+            expect(CatalogFilterResponse2[0].filterDataSize).toEqual(assertItem.catalogFilterResponse[1].filterDataSize);
+            expect(CatalogFilterResponse2[0].requestEndIndex).toEqual(assertItem.catalogFilterResponse[1].requestEndIndex);
+            expect(CatalogFilterResponse2[0].progress).toEqual(assertItem.catalogFilterResponse[1].progress);
+        });
+
+        test(`(Step 8) Request CatalogFilter: Filter(string) & check CatalogFilterResponse | `, async () => {
+            await msgController.setCatalogFilterRequest(assertItem.catalogFilterReq[2]);
+            let CatalogFilterResponse3 = await Stream(CARTA.CatalogFilterResponse, 1);
+            expect(Object.keys(CatalogFilterResponse3[0].columns).length).toEqual(assertItem.catalogFilterResponse[2].lengthOfColumns);
+            expect(CatalogFilterResponse3[0].fileid).toEqual(assertItem.catalogFilterResponse[2].fileId);
+            expect(CatalogFilterResponse3[0].subsetDataSize).toEqual(assertItem.catalogFilterResponse[2].subsetDataSize);
+            expect(CatalogFilterResponse3[0].subsetEndIndex).toEqual(assertItem.catalogFilterResponse[2].subsetEndIndex);
+            expect(CatalogFilterResponse3[0].filterDataSize).toEqual(assertItem.catalogFilterResponse[2].filterDataSize);
+            expect(CatalogFilterResponse3[0].requestEndIndex).toEqual(assertItem.catalogFilterResponse[2].requestEndIndex);
+            expect(CatalogFilterResponse3[0].progress).toEqual(assertItem.catalogFilterResponse[2].progress);
+        });
+
+        test(`(Step 9) Request CatalogFilter: Sorting when Filter(string+number) is applied & check CatalogFilterResponse | `, async () => {
+            await msgController.setCatalogFilterRequest(assertItem.catalogFilterReq[3]);
+            let CatalogFilterResponse4 = await Stream(CARTA.CatalogFilterResponse, 1);
+            expect(Object.keys(CatalogFilterResponse4[0].columns).length).toEqual(assertItem.catalogFilterResponse[3].lengthOfColumns);
+            expect(CatalogFilterResponse4[0].fileid).toEqual(assertItem.catalogFilterResponse[3].fileId);
+            expect(CatalogFilterResponse4[0].subsetDataSize).toEqual(assertItem.catalogFilterResponse[3].subsetDataSize);
+            expect(CatalogFilterResponse4[0].subsetEndIndex).toEqual(assertItem.catalogFilterResponse[3].subsetEndIndex);
+            expect(CatalogFilterResponse4[0].filterDataSize).toEqual(assertItem.catalogFilterResponse[3].filterDataSize);
+            expect(CatalogFilterResponse4[0].requestEndIndex).toEqual(assertItem.catalogFilterResponse[3].requestEndIndex);
+            expect(CatalogFilterResponse4[0].progress).toEqual(assertItem.catalogFilterResponse[3].progress);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CHECK_RASTER_TILE_DATA.test.ts
+++ b/src/test/CHECK_RASTER_TILE_DATA.test.ts
@@ -1,0 +1,353 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+
+interface IRasterTileDataExt extends CARTA.IRasterTileData {
+    assert?: {
+        lengthTiles: number,
+        index: {
+            x: number,
+            y: number
+        },
+        value: number,
+    };
+    imageData?: {
+        length: number,
+        index: number[],
+        value: number[],
+    }
+}
+interface AssertItem {
+    precisionDigit: number;
+    fileOpen: CARTA.IOpenFile;
+    fileOpenAck: CARTA.IOpenFileAck;
+    initTilesReq: CARTA.IAddRequiredTiles;
+    initSetCursor: CARTA.ISetCursor;
+    initSpatialReq: CARTA.ISetSpatialRequirements;
+    setImageChannel: CARTA.ISetImageChannels;
+    rasterTileData: IRasterTileDataExt;
+    addRequiredTilesGroup: CARTA.IAddRequiredTiles[];
+    rasterTileDataGroup: IRasterTileDataExt[];
+}
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "cluster_04096.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    fileOpenAck: {
+        success: true,
+        fileFeatureFlags: 0,
+    },
+    initTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.NONE,
+        tiles: [0],
+    },
+    initSetCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    initSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+    },
+    setImageChannel: {
+        fileId: 0,
+        channel: 0,
+        requiredTiles: {
+            fileId: 0,
+            tiles: [0],
+            compressionType: CARTA.CompressionType.NONE,
+        },
+    },
+    rasterTileData: {
+        fileId: 0,
+        channel: 0,
+        stokes: 0,
+        compressionType: CARTA.CompressionType.NONE,
+        tiles: [
+            {
+                x: 0,
+                y: 0,
+                layer: 0,
+                height: 256,
+                width: 256,
+            },
+        ],
+        assert: {
+            lengthTiles: 1,
+            index: { x: 256, y: 256 },
+            value: 2.72519,
+        }
+    },
+    addRequiredTilesGroup: [
+        {
+            fileId: 0,
+            tiles: [16781313], // Hex1001001
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+        {
+            fileId: 0,
+            tiles: [33566723], // Hex2003003
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+        {
+            fileId: 0,
+            tiles: [50360327], // Hex3007007
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+        {
+            fileId: 0,
+            tiles: [67170319], // Hex400F00F
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+    ],
+    rasterTileDataGroup: [
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [
+                {
+                    x: 1,
+                    y: 1,
+                    layer: 1,
+                    height: 256,
+                    width: 256,
+                },
+            ],
+            imageData: {
+                length: 215608,
+                index: [0, 50000, 100000, 150000, 200000],
+                value: [9, 56, 75, 120, 216],
+            }
+        },
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [
+                {
+                    x: 3,
+                    y: 3,
+                    layer: 2,
+                    height: 256,
+                    width: 256,
+                },
+            ],
+            imageData: {
+                length: 225896,
+                index: [0, 50000, 100000, 150000, 200000],
+                value: [5, 193, 250, 96, 18],
+            }
+        },
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [
+                {
+                    x: 7,
+                    y: 7,
+                    layer: 3,
+                    height: 256,
+                    width: 256,
+                },
+            ],
+            imageData: {
+                length: 233272,
+                index: [0, 50000, 100000, 150000, 200000],
+                value: [5, 150, 140, 21, 199],
+            }
+        },
+        {
+            fileId: 0,
+            channel: 0,
+            stokes: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [
+                {
+                    x: 15,
+                    y: 15,
+                    layer: 4,
+                    height: 256,
+                    width: 256,
+                },
+            ],
+            imageData: {
+                length: 237208,
+                index: [0, 50000, 100000, 150000, 200000],
+                value: [5, 66, 31, 93, 39],
+            }
+        },
+    ],
+};
+
+let basepath: string;
+describe("CHECK_RASTER_TILE_DATA: Testing data values at different layers in RASTER_TILE_DATA", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.fileOpen.directory;
+        });
+
+        test(`Preparation: Open image`,async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+            expect(OpenFileResponse.success).toEqual(true);
+            let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+        });
+
+        let RasterTileDataTemp: CARTA.RasterTileData;
+        test(`RasterTileData * 1 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)?`, async () => {
+            await msgController.addRequiredTiles(assertItem.initTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+
+            await msgController.setCursor(assertItem.initSetCursor.fileId, assertItem.initSetCursor.point.x, assertItem.initSetCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            await msgController.setSpatialRequirements(assertItem.initSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+        }, readFileTimeout);
+
+        describe(`SET_IMAGE_CHANNELS on the file "${assertItem.fileOpen.file}"`, () => {
+            let RasterTileDataTemp: CARTA.RasterTileData;
+            test(`RASTER_TILE_DATA should arrive within ${readFileTimeout} ms`, async () => {
+                await msgController.setChannels(assertItem.setImageChannel);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData, assertItem.setImageChannel.requiredTiles.tiles.length + 2);
+                RasterTileDataTemp = RasterTileDataResponse[1];
+            }, readFileTimeout);
+
+            test(`RASTER_TILE_DATA.file_id = ${assertItem.rasterTileData.fileId}`, () => {
+                expect(RasterTileDataTemp.fileId).toEqual(assertItem.rasterTileData.fileId);
+            });
+
+            test(`RASTER_TILE_DATA.channel = ${assertItem.rasterTileData.channel}`, () => {
+                expect(RasterTileDataTemp.channel).toEqual(assertItem.rasterTileData.channel);
+            });
+
+            test(`RASTER_TILE_DATA.stokes = ${assertItem.rasterTileData.stokes}`, () => {
+                expect(RasterTileDataTemp.stokes).toEqual(assertItem.rasterTileData.stokes);
+            });
+
+            test(`RASTER_TILE_DATA.compression_type = ${assertItem.rasterTileData.compressionType}`, () => {
+                expect(RasterTileDataTemp.compressionType).toEqual(assertItem.rasterTileData.compressionType);
+            });
+
+            test(`RASTER_TILE_DATA.tiles.length = ${assertItem.rasterTileData.assert.lengthTiles}`, () => {
+                expect(RasterTileDataTemp.tiles.length).toEqual(assertItem.rasterTileData.assert.lengthTiles);
+            });
+
+            test(`RASTER_TILE_DATA.tiles[0].x = ${assertItem.rasterTileData.tiles[0].x}`, () => {
+                expect(RasterTileDataTemp.tiles[0].x).toEqual(assertItem.rasterTileData.tiles[0].x);
+            });
+
+            test(`RASTER_TILE_DATA.tiles[0].y = ${assertItem.rasterTileData.tiles[0].y}`, () => {
+                expect(RasterTileDataTemp.tiles[0].y).toEqual(assertItem.rasterTileData.tiles[0].y);
+            });
+
+            test(`RASTER_TILE_DATA.tiles[0].layer = ${assertItem.rasterTileData.tiles[0].layer}`, () => {
+                expect(RasterTileDataTemp.tiles[0].layer).toEqual(assertItem.rasterTileData.tiles[0].layer);
+            });
+
+            test(`RASTER_TILE_DATA.tiles[0].height = ${assertItem.rasterTileData.tiles[0].height}`, () => {
+                expect(RasterTileDataTemp.tiles[0].height).toEqual(assertItem.rasterTileData.tiles[0].height);
+            });
+
+            test(`RASTER_TILE_DATA.tiles[0].width = ${assertItem.rasterTileData.tiles[0].width}`, () => {
+                expect(RasterTileDataTemp.tiles[0].width).toEqual(assertItem.rasterTileData.tiles[0].width);
+            });
+
+            test(`RASTER_TILE_DATA.tiles[0].image_data${JSON.stringify(assertItem.rasterTileData.assert.index)} = ${assertItem.rasterTileData.assert.value}`, () => {
+                const _x = assertItem.rasterTileData.assert.index.x;
+                const _y = assertItem.rasterTileData.assert.index.y;
+                const _dataView = new DataView(RasterTileDataTemp.tiles[0].imageData.slice((_x * _y - 1) * 4, _x * _y * 4).buffer);
+                expect(_dataView.getFloat32(0, true)).toBeCloseTo(assertItem.rasterTileData.assert.value, assertItem.precisionDigit);
+            });
+        });
+
+        assertItem.rasterTileDataGroup.map((rasterTileData, index) => {
+            describe(`ADD_REQUIRED_TILES [${assertItem.addRequiredTilesGroup[index].tiles}]`, () => {
+                let RasterTileDataTemp: CARTA.RasterTileData;
+                test(`RASTER_TILE_DATA should arrive within ${readFileTimeout} ms`, async () => {
+                    await msgController.addRequiredTiles(assertItem.addRequiredTilesGroup[index]);
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData, assertItem.addRequiredTilesGroup[index].tiles.length + 2);
+                    RasterTileDataTemp = RasterTileDataResponse[1];
+                }, readFileTimeout);
+
+                test(`RASTER_TILE_DATA.file_id = ${rasterTileData.fileId}`, () => {
+                    expect(RasterTileDataTemp.fileId).toEqual(rasterTileData.fileId);
+                });
+
+                test(`RASTER_TILE_DATA.channel = ${rasterTileData.channel}`, () => {
+                    expect(RasterTileDataTemp.channel).toEqual(rasterTileData.channel);
+                });
+
+                test(`RASTER_TILE_DATA.stokes = ${rasterTileData.stokes}`, () => {
+                    expect(RasterTileDataTemp.stokes).toEqual(rasterTileData.stokes);
+                });
+
+                test(`RASTER_TILE_DATA.compression_type = ${rasterTileData.compressionType}`, () => {
+                    expect(RasterTileDataTemp.compressionType).toEqual(rasterTileData.compressionType);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].x = ${rasterTileData.tiles[0].x}`, () => {
+                    expect(RasterTileDataTemp.tiles[0].x).toEqual(rasterTileData.tiles[0].x);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].y = ${rasterTileData.tiles[0].y}`, () => {
+                    expect(RasterTileDataTemp.tiles[0].y).toEqual(rasterTileData.tiles[0].y);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].layer = ${rasterTileData.tiles[0].layer}`, () => {
+                    expect(RasterTileDataTemp.tiles[0].layer).toEqual(rasterTileData.tiles[0].layer);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].height = ${rasterTileData.tiles[0].height}`, () => {
+                    expect(RasterTileDataTemp.tiles[0].height).toEqual(rasterTileData.tiles[0].height);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].width = ${rasterTileData.tiles[0].width}`, () => {
+                    expect(RasterTileDataTemp.tiles[0].width).toEqual(rasterTileData.tiles[0].width);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].imageData.length = ${rasterTileData.imageData.length}`, () => {
+                    expect(RasterTileDataTemp.tiles[0].imageData.length).toEqual(rasterTileData.imageData.length);
+                });
+
+                test(`RASTER_TILE_DATA.tiles[0].image_data${JSON.stringify(rasterTileData.imageData.index)} = [${rasterTileData.imageData.value}]`, () => {
+                    for (let i = 0; i < rasterTileData.imageData.index.length; i++) {
+                        expect(RasterTileDataTemp.tiles[0].imageData[rasterTileData.imageData.index[i]]).toEqual(rasterTileData.imageData.value[i])
+                    }
+                });
+
+            });
+        });
+
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CLOSE_FILE_ANIMATION.test.ts
+++ b/src/test/CLOSE_FILE_ANIMATION.test.ts
@@ -1,0 +1,172 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+import * as Long from "long";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile;
+let playAnimatorTimeout = config.timeout.playAnimator;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addRequiredTiles: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor;
+    setSpatialReq: CARTA.ISetSpatialRequirements;
+    startAnimation: CARTA.IStartAnimation;
+    animationFlowControl: CARTA.IAnimationFlowControl;
+    AnimatorStopChannel: number;
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addRequiredTiles: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+        },
+        {
+            fileId: 0,
+            compressionQuality: 9,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+        },
+    ],
+    setCursor:
+    {
+        fileId: 0,
+        point: { x: 320, y: 400 },
+    },
+    setSpatialReq:
+    {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+    },
+    startAnimation:
+    {
+        fileId: 0,
+        startFrame: { channel: 1, stokes: 0 },
+        firstFrame: { channel: 0, stokes: 0 },
+        lastFrame: { channel: 24, stokes: 0 },
+        deltaFrame: { channel: 1, stokes: 0 },
+        requiredTiles: {
+            fileId: 0,
+            tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 9,
+        },
+    },
+    animationFlowControl: {
+        fileId: 0,
+        animationId: 1,
+    },
+    AnimatorStopChannel: 2,
+};
+
+let basepath: string;
+describe("Testing CLOSE_FILE with large-size image and test CLOSE_FILE during the TILE data streaming :", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.fileOpen.directory;
+            assertItem.filelist.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen.file);
+        }, openFileTimeout);
+
+        test(`(Step 2) return RASTER_TILE_DATA(Stream) and check total length | `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles[0]);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles[0].tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(assertItem.addRequiredTiles[0].tiles.length + 2); //RasterTileSync: start & end + 12 Tile returned
+        }, readFileTimeout);
+
+        let sequence: number[] = [];
+        test(`(Step 3) START_ANIMATION & ANIMATION_FLOW_CONTROL, then CLOSE_FILE during the animation streaming & Check whether the backend is alive:`, async () => {
+            let StartAnimationResponse: CARTA.IStartAnimationAck;
+            StartAnimationResponse = await msgController.startAnimation({
+                ...assertItem.startAnimation,
+                looping: true,
+                reverse: false,
+                frameRate: 5,
+            });
+            expect(StartAnimationResponse.success).toEqual(true);
+            msgController.addRequiredTiles(assertItem.addRequiredTiles[1]);
+            for (let i = 0; i < assertItem.AnimatorStopChannel; i++) {
+                let RegionHistogramData: CARTA.RegionHistogramData[] = [];
+                msgController.histogramStream.pipe(take(1)).subscribe({
+                    next: (data) => {
+                        RegionHistogramData.push(data);
+                    },
+                    complete: () => {
+                        expect(RegionHistogramData[0].channel).toEqual(i+1);
+                    }
+                })
+                let RasterTileData = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles[1].tiles.length + 2);
+                sequence.push(RasterTileData[0].channel);
+                msgController.sendAnimationFlowControl({
+                    ...assertItem.animationFlowControl,
+                    receivedFrame: {
+                        channel: RasterTileData[0].channel,
+                        stokes: 0
+                    },
+                    timestamp: Long.fromNumber(Date.now()),
+                });
+            }
+
+            // CLOSE_FILE before STOP_ANIMATION (NO STOP_ANIMATION in this test!)
+            msgController.closeFile(0);
+
+            // The backend may still returning the remain message
+            // To check whether the backend is still alive
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+        }, playAnimatorTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+})
+

--- a/src/test/CLOSE_FILE_ANIMATION.test.ts
+++ b/src/test/CLOSE_FILE_ANIMATION.test.ts
@@ -163,7 +163,7 @@ describe("Testing CLOSE_FILE with large-size image and test CLOSE_FILE during th
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
         }, playAnimatorTimeout);
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/CLOSE_FILE_ERROR.test.ts
+++ b/src/test/CLOSE_FILE_ERROR.test.ts
@@ -1,0 +1,194 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile
+
+interface AssertItem {
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile[];
+    addRequiredTiles: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements;
+    ErrorMessage: CARTA.IErrorData;
+};
+
+let assertItem: AssertItem = {
+    filelist: { directory: testSubdirectory },
+    fileOpen: [
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.fits",
+            hdu: "0",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.hdf5",
+            hdu: "0",
+            fileId: 1,
+            renderMode: CARTA.RenderMode.RASTER,
+        }
+    ],
+    addRequiredTiles: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor:
+        [
+            {
+                fileId: 0,
+                point: { x: 1, y: 1 },
+            },
+            {
+                fileId: 1,
+                point: { x: 1, y: 1 },
+            }
+        ],
+    setSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+    },
+    ErrorMessage: {
+        tags: ['cursor'],
+        message: 'File id 1 not found',
+    },
+};
+
+let basepath: string;
+describe("[Case 1] Test for requesting the ICD message of the CLOSED image:", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.filelist.directory = basepath + "/" + assertItem.filelist.directory;
+            assertItem.fileOpen[0].directory = basepath + "/" + assertItem.fileOpen[0].directory;
+            assertItem.fileOpen[1].directory = basepath + "/" + assertItem.fileOpen[1].directory;
+        });
+
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA of fileId = 0 should arrive within ${openFileTimeout} ms `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen[0]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen[0].file);
+        }, openFileTimeout);
+
+        test(`(Step 2) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA of fileId = 1 should arrive within ${openFileTimeout} ms `, async () => {
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen[1]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen[1].file);
+        }, openFileTimeout);
+
+        test(`(Step 3) close fileId =1 & request ICD message of the closed fileId=1, then the backend is still alive:`, async () => {
+            //close fileId =1
+            msgController.closeFile(1);
+    
+            //request ICD message of the closed fileId=1
+            msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y)
+            let ErrMesssage = await Stream(CARTA.ErrorData, 1);
+            expect(ErrMesssage[0].tags).toEqual(assertItem.ErrorMessage.tags);
+            expect(ErrMesssage[0].message).toEqual(assertItem.ErrorMessage.message);
+    
+            // //check the backend is still alive
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+        });
+
+        test(`(Step 4) Test fileId = 0 is still working well: `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+});
+
+describe("[Case 2] Open=>Close=>Open of fileId=0, and then check the backend alive:", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA of fileId = 0 should arrive within ${openFileTimeout} ms `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen[0]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen[0].file);
+        }, openFileTimeout);
+
+        test(`(Step 2) return RASTER_TILE_DATA(Stream) and check total length`, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, openFileTimeout);
+
+        test(`(Step 3) Closed and Re-open `, async () => {
+            //Close fileid=0
+            msgController.closeFile(0);
+    
+            //Re-opne fileid=0
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen[0]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen[0].file);
+    
+            //ICD messages work fine?
+            msgController.addRequiredTiles(assertItem.addRequiredTiles);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles.tiles.length + 2);
+            msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        });
+
+        test(`(Step 4) the backend is still alive`, async () => {
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+        }, readFileTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/CLOSE_FILE_ERROR.test.ts
+++ b/src/test/CLOSE_FILE_ERROR.test.ts
@@ -186,7 +186,7 @@ describe("[Case 2] Open=>Close=>Open of fileId=0, and then check the backend ali
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
         }, readFileTimeout);
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/CLOSE_FILE_ERROR.test.ts
+++ b/src/test/CLOSE_FILE_ERROR.test.ts
@@ -112,7 +112,7 @@ describe("[Case 1] Test for requesting the ICD message of the CLOSED image:", ()
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
         });
 
         test(`(Step 4) Test fileId = 0 is still working well: `, async () => {

--- a/src/test/CLOSE_FILE_SINGLE.test.ts
+++ b/src/test/CLOSE_FILE_SINGLE.test.ts
@@ -1,0 +1,105 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile
+
+interface AssertItem {
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addRequiredTiles: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setSpatialReq: CARTA.ISetSpatialRequirements;
+};
+
+let assertItem: AssertItem = {
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addRequiredTiles: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+    },
+};
+
+let basepath: string;
+describe("Test for Close single file:", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+            assertItem.filelist.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+        }, openFileTimeout);
+
+        test(`(Step 2) return RASTER_TILE_DATA(Stream) and check total length | `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        test(`(Step 3) close image and check there is no receiving message`, done => {
+            msgController.closeFile(0);
+
+            let receiveNumberCurrent = msgController.messageReceiving();
+            setTimeout(() => {
+                let receiveNumberLatter = msgController.messageReceiving();
+                expect(receiveNumberCurrent).toEqual(receiveNumberLatter)
+                done();
+            }, 1000)
+        })
+
+        test(`(Step 4) close image & the backend is still alive`, async () => {
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})
+

--- a/src/test/CLOSE_FILE_SINGLE.test.ts
+++ b/src/test/CLOSE_FILE_SINGLE.test.ts
@@ -96,7 +96,7 @@ describe("Test for Close single file:", () => {
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts
+++ b/src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts
@@ -337,7 +337,7 @@ describe("[Case 2] Request SPECTRAL_REQUIREMENTS of TWO images and then CLOSE_FI
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts
+++ b/src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts
@@ -205,7 +205,7 @@ describe("[Case 1] Request SPECTRAL_REQUIREMENTS and then CLOSE_FILE when data i
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
 
         }, largeImageTimeout)
 

--- a/src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts
+++ b/src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts
@@ -1,0 +1,345 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile;
+let largeImageTimeout = config.timeout.readLargeImage;
+
+interface AssertItem {
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile[];
+    addRequiredTiles: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    regionAck: CARTA.ISetRegionAck;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements[];
+};
+
+let assertItem: AssertItem = {
+    filelist: { directory: testSubdirectory },
+    openFile: [
+        {
+            directory:  testSubdirectory,
+            file: "S255_IR_sci.spw29.cube.I.pbcor.fits",
+            hdu: "0",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "S255_IR_sci.spw25.cube.I.pbcor.fits",
+            hdu: "0",
+            fileId: 1,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    addRequiredTiles: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1,
+            point: { x: 1, y: 1 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+        },
+        {
+            fileId: 1,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 630.0, y: 1060.0 }, { x: 600.0, y: 890.0 }],
+                rotation: 0.0,
+            }
+        },
+        {
+            fileId: 1,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 630.0, y: 1060.0 }, { x: 600.0, y: 890.0 }],
+                rotation: 0.0,
+            }
+        },
+    ],
+    regionAck:
+    {
+        success: true,
+        regionId: 1,
+    },
+    setSpectralRequirements: [
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [],
+        },
+        {
+            fileId: 1,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+    ],
+};
+
+let basepath: string;
+describe("[Case 1] Request SPECTRAL_REQUIREMENTS and then CLOSE_FILE when data is still streaming :", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
+            assertItem.filelist.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile[0]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[0].file);
+        }, openFileTimeout);
+
+        test(`(Step 2) return RASTER_TILE_DATA(Stream) and check total length | `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles[0]);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles[0].tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        let SpectralProfileDataTemp = [];
+        let ReceiveProgress: number;
+        test(`(Step 3) Set REGION & SPECTRAL_PROFILE streaming, once progress>0.3 then CLOSE_FILE & Check whether the backend is alive:`, async() => {
+            // Set REGION
+            let SetRegionAckTemp = await msgController.setRegion(assertItem.setRegion[0].fileId,assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+            expect(SetRegionAckTemp.regionId).toEqual(assertItem.regionAck.regionId);
+            expect(SetRegionAckTemp.success).toEqual(assertItem.regionAck.success);
+
+            //Set SPECTRAL_PROFILE streaming
+            msgController.setSpectralRequirements(assertItem.setSpectralRequirements[0]);
+            let spectralProfileDataPromise = new Promise((resolve)=>{
+                msgController.spectralProfileStream.subscribe({
+                    next: (data) => {
+                        SpectralProfileDataTemp.push(data)
+                        ReceiveProgress = data.progress;
+                        if (ReceiveProgress > 0.3) {
+                            resolve(SpectralProfileDataTemp)
+                        }
+                    },
+                })
+            }) 
+            let spectralProfileDataResponse = await spectralProfileDataPromise;
+            for (let i = 0; i < spectralProfileDataResponse.length; i++) {
+                console.log('' + assertItem.openFile[0].file + ' SPECTRAL_PROFILE progress :', spectralProfileDataResponse[i].progress);
+            }
+
+            //Once progress>0.3, then CLOSE_FILE
+            msgController.closeFile(0);
+
+            //Check whether the backend ist alive?
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+
+        }, largeImageTimeout)
+
+        afterAll(() => msgController.closeConnection());
+    });
+})
+
+
+describe("[Case 2] Request SPECTRAL_REQUIREMENTS of TWO images and then CLOSE_FILE when the SECOND data is still streaming :", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+            
+        }, connectTimeout);
+
+        checkConnection();
+        test(`(Step 1) IMAGE 1 : OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile[0]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[0].file);
+        }, openFileTimeout);
+
+        test(`(Step 2) IMAGE 1 : return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles[0]);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles[0].tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        test(`(Step 3) IMAGE 2 : OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+            msgController.closeFile(1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile[1]);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[1].file);
+        }, openFileTimeout);
+
+        test(`(Step 4) IMAGE 2 : return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles[1]);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles[1].tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq[1]);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        let SetRegionAckTemp: CARTA.SetRegionAck;
+        let SpectralProfileDataTemp1 = [];
+        let ReceiveProgress1: number;
+        let SpectralProfileDataTemp2 = [];
+        let ReceiveProgress2: number;
+        test(`(Step 5) Set REGION & SPECTRAL_PROFILE streaming, once progress1>0.3 -> progress2>0.3 -> CLOSE_FILE two images`, async() => {
+            // Set REGION
+            let SetRegionAckTemp = await msgController.setRegion(assertItem.setRegion[0].fileId,assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+            expect(SetRegionAckTemp.regionId).toEqual(assertItem.regionAck.regionId);
+            expect(SetRegionAckTemp.success).toEqual(assertItem.regionAck.success);
+
+            //Set 1st image SPECTRAL_PROFILE streaming
+            msgController.setSpectralRequirements(assertItem.setSpectralRequirements[0]);
+            let spectralProfileDataPromise1 = new Promise((resolve)=>{
+                msgController.spectralProfileStream.subscribe({
+                    next: (data) => {
+                        SpectralProfileDataTemp1.push(data)
+                        ReceiveProgress1 = data.progress;
+                        if (ReceiveProgress1 > 0.3) {
+                            resolve(SpectralProfileDataTemp1)
+                        }
+                    },
+                })
+            }) 
+            let spectralProfileDataResponse1 = await spectralProfileDataPromise1;
+            for (let i = 0; i < spectralProfileDataResponse1.length; i++) {
+                console.log('(Case 2) 1st image:' + assertItem.openFile[0].file + ' SPECTRAL_PROFILE progress :', spectralProfileDataResponse1[i].progress);
+            }
+
+            msgController.setSpectralRequirements(assertItem.setSpectralRequirements[1]);
+
+            // Set  2nd image SPECTRAL_PROFILE streaming
+            msgController.setSpectralRequirements(assertItem.setSpectralRequirements[2]);
+            let spectralProfileDataPromise2 = new Promise((resolve)=>{
+                msgController.spectralProfileStream.subscribe({
+                    next: (data) => {
+                        SpectralProfileDataTemp2.push(data)
+                        ReceiveProgress2 = data.progress;
+                        if (ReceiveProgress2 > 0.3) {
+                            resolve(SpectralProfileDataTemp2)
+                        }
+                    },
+                })
+            }) 
+            let spectralProfileDataResponse2 = await spectralProfileDataPromise2;
+            for (let i = 0; i < spectralProfileDataResponse2.length; i++) {
+                console.log('(Case 2) 2nd image:' + assertItem.openFile[1].file + ' SPECTRAL_PROFILE progress :', spectralProfileDataResponse2[i].progress);
+            }
+
+            //Once ReceiveProgress2>0.3, then CLOSE_FILE to 1st & 2nd image
+            msgController.closeFile(0);
+            msgController.closeFile(1);
+            
+        }, largeImageTimeout)
+
+        test(`(Step 6) check there is no receiving message`, done => {
+            msgController.closeFile(0);
+
+            let receiveNumberCurrent = msgController.messageReceiving();
+            setTimeout(() => {
+                let receiveNumberLatter = msgController.messageReceiving();
+                expect(receiveNumberCurrent).toEqual(receiveNumberLatter)
+                done();
+            }, 1000)
+        })
+
+        test(`(Step 7) the backend is still alive`, async () => {
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/CLOSE_FILE_TILE.test.ts
+++ b/src/test/CLOSE_FILE_TILE.test.ts
@@ -1,0 +1,118 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let readFileTimeout: number = config.timeout.readFile;
+
+interface AssertItem {
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addRequiredTiles: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setSpatialReq: CARTA.ISetSpatialRequirements;
+    setImageChannel: CARTA.ISetImageChannels;
+};
+
+let assertItem: AssertItem = {
+    filelist: { directory: testSubdirectory },
+    fileOpen:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addRequiredTiles:
+    {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor:
+    {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setSpatialReq:
+    {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+    },
+    setImageChannel:
+    {
+        fileId: 0,
+        channel: 10,
+        stokes: 0,
+        requiredTiles: {
+            fileId: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+            tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+        },
+    },
+
+};
+
+let basepath: string;
+describe("Testing CLOSE_FILE with large-size image and test CLOSE_FILE during the TILE data streaming :", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.fileOpen.directory;
+            assertItem.filelist.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        test(`(Step 1) OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.fileOpen.file);
+        }, openFileTimeout);
+
+        test(`(Step 2) return RASTER_TILE_DATA(Stream) and check total length | `, async () => {
+            msgController.addRequiredTiles(assertItem.addRequiredTiles);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addRequiredTiles.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            msgController.setSpatialRequirements(assertItem.setSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        test(`(Step 3) Set SET_IMAGE_CHANNELS and then CLOSE_FILE during the tile streaming & Check whether the backend is alive:`, async () => {
+            msgController.setChannels(assertItem.setImageChannel);
+            // Interupt during the tile, we will receive the number <  assertItem.setImageChannel.requiredTiles.tiles.length
+            let ReceiveData = await Stream(CARTA.RasterTileData, 2);
+            // CLOSE_FILE during the tile streaming
+            msgController.closeFile(0);
+
+            let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
+            expect(BackendStatus).toBeDefined();
+            expect(BackendStatus.success).toBe(true);
+            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})
+

--- a/src/test/CLOSE_FILE_TILE.test.ts
+++ b/src/test/CLOSE_FILE_TILE.test.ts
@@ -109,7 +109,7 @@ describe("Testing CLOSE_FILE with large-size image and test CLOSE_FILE during th
             let BackendStatus = await msgController.getFileList(assertItem.filelist.directory, assertItem.filelist.filterMode);
             expect(BackendStatus).toBeDefined();
             expect(BackendStatus.success).toBe(true);
-            expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
+            expect(BackendStatus.directory).toContain("set_QA");
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/DS9_REGION_EXPORT.test.ts
+++ b/src/test/DS9_REGION_EXPORT.test.ts
@@ -1,0 +1,375 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+let exportTimeout = config.timeout.export;
+
+interface ImportRegionAckExt extends CARTA.IImportRegionAck {
+    lengthOfRegions?: number;
+    assertRegionId?: {
+        index: number,
+        id: number,
+    };
+};
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    precisionDigits: number;
+    setRegion: CARTA.ISetRegion[];
+    exportRegion: CARTA.IExportRegion[];
+    exportRegionAck: CARTA.IExportRegionAck[];
+    importRegion: CARTA.IImportRegion[];
+    importRegionAck: ImportRegionAckExt[];
+};
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    precisionDigits: 4,
+    setRegion:
+        [
+            {
+                fileId: 0,
+                regionId: -1,   // 1
+                regionInfo: {
+                    regionType: CARTA.RegionType.POINT,
+                    rotation: 0,
+                    controlPoints: [{ x: -109.579, y: 618.563 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 2
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: -114.748, y: 508.708 }, { x: 90.468, y: 90.468 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 3
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: -114.748, y: 332.941 }, { x: 170.597, y: 64.620 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 4
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                    controlPoints: [{ x: -126.380, y: 167.512 }, { x: 149.919, y: 38.772 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 5
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 758.918, y: 634.071 }, { x: 62.035, y: 62.035 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 6
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 751.163, y: 444.088 }, { x: 29.725, y: 93.053 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 7
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                    controlPoints: [{ x: 749.871, y: 290.291 }, { x: 25.848, y: 84.006 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 8
+                regionInfo: {
+                    regionType: CARTA.RegionType.POLYGON,
+                    rotation: 0,
+                    controlPoints: [{ x: 757.626, y: 184.314 }, { x: 698.175, y: 66.7051 }, { x: 831.293, y: 106.769 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 9
+                regionInfo: {
+                    regionType: CARTA.RegionType.POINT,
+                    rotation: 0,
+                    controlPoints: [{ x: 199.306, y: 565.574 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 10
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: 192.844, y: 473.813 }, { x: 67.205, y: 67.205 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 11
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 0,
+                    controlPoints: [{ x: 174.750, y: 360.081 }, { x: 118.901, y: 46.526 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 12
+                regionInfo: {
+                    regionType: CARTA.RegionType.RECTANGLE,
+                    rotation: 45,
+                    controlPoints: [{ x: 204.475, y: 254.104 }, { x: 121.486, y: 46.526 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 13
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 415.138, y: 553.942 }, { x: 45.234, y: 45.234 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 14
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 0,
+                    controlPoints: [{ x: 406.091, y: 423.409 }, { x: 20.678, y: 68.497 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 15
+                regionInfo: {
+                    regionType: CARTA.RegionType.ELLIPSE,
+                    rotation: 45,
+                    controlPoints: [{ x: 399.629, y: 331.648 }, { x: 19.386, y: 71.082 }],
+                },
+            },
+            {
+                fileId: 0,
+                regionId: -1,   // 16
+                regionInfo: {
+                    regionType: CARTA.RegionType.POLYGON,
+                    rotation: 0,
+                    controlPoints: [{ x: 416.430, y: 229.548 }, { x: 335.008, y: 92.553 }, { x: 513.361, y: 135.202 }],
+                },
+            },
+        ],
+    exportRegion:
+        [
+            {
+                coordType: CARTA.CoordinateType.WORLD,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_handMadeRegions_world.reg",
+                fileId: 0,
+                type: CARTA.FileType.DS9_REG,
+                regionStyles: {
+                    // '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '9': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '10': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '11': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '12': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '13': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '14': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '15': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '16': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                },
+            },
+            {
+                coordType: CARTA.CoordinateType.PIXEL,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_handMadeRegions_pix.reg",
+                fileId: 0,
+                type: CARTA.FileType.DS9_REG,
+                regionStyles: {
+                    // '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '8': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '9': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '10': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '11': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '12': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '13': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '14': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '15': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    // '16': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                },
+            },
+        ],
+    exportRegionAck:
+        [
+            {
+                success: true,
+                contents: [],
+            },
+            {
+                success: true,
+                contents: [],
+            },
+        ],
+    importRegion:
+        [
+            {
+                contents: [],
+                file: "M17_SWex_handMadeRegions_world.reg",
+                groupId: 0,
+                type: CARTA.FileType.DS9_REG,
+            },
+            {
+                contents: [],
+                file: "M17_SWex_handMadeRegions_pix.reg",
+                groupId: 0,
+                type: CARTA.FileType.DS9_REG,
+            },
+        ],
+    importRegionAck:
+        [
+            {
+                success: true,
+                lengthOfRegions: 16,
+                assertRegionId: {
+                    index: 15,
+                    id: 32,
+                },
+            },
+            {
+                success: true,
+                lengthOfRegions: 16,
+                assertRegionId: {
+                    index: 15,
+                    id: 48,
+                },
+            },
+        ],
+};
+
+let basepath: string;
+describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file} and set regions"`, () => {
+            test(`Preparation: Open image and set regions`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                for (let region of assertItem.setRegion) {
+                    let RegionAckResponse = await msgController.setRegion(region.fileId, region.regionId, region.regionInfo);
+                    expect(RegionAckResponse.success).toBe(true);
+                }
+            });
+
+            assertItem.exportRegionAck.map((exRegion, idxRegion) => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                    let exportRegionAck: any;
+                    test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(2, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(3, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(4, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(5, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(6, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(7, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(8, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(9, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(10, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(11, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(12, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(13, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(14, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(15, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+                        regionStyle.set(16, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
+
+                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle)
+                    }, exportTimeout);
+    
+                    test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
+                        expect(exportRegionAck.success).toBe(exRegion.success);
+                    });
+    
+                    test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
+                        expect(exportRegionAck.contents).toEqual(exRegion.contents);
+                    });
+                });
+            });
+
+            assertItem.importRegionAck.map((Region, idxRegion) => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    let importRegionAckProperties: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        assertItem.importRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        importRegionAck = await msgController.importRegion(assertItem.importRegion[idxRegion].directory, assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId)
+                        importRegionAckProperties = Object.keys(importRegionAck.regions)
+                    }, importTimeout);
+    
+                    test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
+                        expect(importRegionAck.success).toBe(Region.success);
+                    });
+    
+                    test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
+                        expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
+                    });
+    
+                    test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
+                        expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
+                    });
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/DS9_REGION_EXPORT.test.ts
+++ b/src/test/DS9_REGION_EXPORT.test.ts
@@ -6,6 +6,7 @@ import config from "./config.json";
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let regionSubdirectory = config.path.region;
+let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 let exportTimeout = config.timeout.export;
@@ -311,7 +312,7 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
             });
 
             assertItem.exportRegionAck.map((exRegion, idxRegion) => {
-                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
                     let exportRegionAck: any;
                     test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                         let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
@@ -331,7 +332,7 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
                         regionStyle.set(15, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
                         regionStyle.set(16, { name: "", color: "#2EE6D6", lineWidth: 2, dashList: [] });
 
-                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        assertItem.exportRegion[idxRegion].directory = saveSubdirectory; 
                         exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle)
                     }, exportTimeout);
     
@@ -346,11 +347,11 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
             });
 
             assertItem.importRegionAck.map((Region, idxRegion) => {
-                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}" from ${saveSubdirectory}`, () => {
                     let importRegionAck: any;
                     let importRegionAckProperties: any;
                     test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        assertItem.importRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        assertItem.importRegion[idxRegion].directory = saveSubdirectory; 
                         importRegionAck = await msgController.importRegion(assertItem.importRegion[idxRegion].directory, assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId)
                         importRegionAckProperties = Object.keys(importRegionAck.regions)
                     }, importTimeout);

--- a/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
@@ -1,0 +1,98 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    precisionDigits: number;
+    importRegion: CARTA.IImportRegion[];
+    importRegionAck: CARTA.IImportRegionAck[];
+};
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    precisionDigits: 4,
+    importRegion:
+        [
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_regionSet2_pix.reg",
+                groupId: 0,
+                type: CARTA.FileType.DS9_REG,
+            },
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_regionSet2_world.reg",
+                groupId: 0,
+                type: CARTA.FileType.DS9_REG,
+            },
+        ],
+    importRegionAck:
+        [
+            { message: "Region import failed: Not a valid DS9 region file" },
+            { message: "Region import failed: Not a valid DS9 region file" },
+        ],
+};
+
+let basepath: string;
+describe("DS9_REGION_IMPORT_EXCEPTION test: Testing import/export of DS9 region format", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            });
+
+            assertItem.importRegionAck.map((regionAck, idxRegion) => {
+                describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms and check the returned error message`, async () => {
+                        try {
+                            importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory, assertItem.importRegion[idxRegion].file, assertItem.importRegion[idxRegion].type, assertItem.importRegion[idxRegion].groupId);
+                        } catch (err) {
+                            expect(err).toContain(assertItem.importRegionAck[idxRegion].message);
+                        }
+                    }, importTimeout);
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -6,6 +6,7 @@ import config from "./config.json";
 let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let regionSubdirectory = config.path.region;
+let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 let exportTimeout = config.timeout.export;
@@ -108,7 +109,6 @@ let assertItem: AssertItem = {
         [
             {
                 coordType: CARTA.CoordinateType.WORLD,
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.reg",
                 fileId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -121,15 +121,12 @@ let assertItem: AssertItem = {
                     '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                     '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                 },
-                // regionId: [1, 2, 3, 4, 5, 6, 7],
             },
             {
                 coordType: CARTA.CoordinateType.PIXEL,
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.reg",
                 fileId: 0,
                 type: CARTA.FileType.DS9_REG,
-                // regionId: [1, 2, 3, 4, 5, 6, 7],
                 regionStyles: {
                     '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
                     '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
@@ -156,14 +153,12 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
             },
             {
                 contents: [],
-                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -249,7 +244,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             });
 
             assertItem.exportRegionAck.map((exRegion, idxRegion) => {
-                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}" to ${saveSubdirectory}`, () => {
                     let exportRegionAck: any;
                     test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                         let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
@@ -261,7 +256,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                         regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
                         regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
 
-                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        assertItem.exportRegion[idxRegion].directory = saveSubdirectory; 
                         exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
                     }, exportTimeout);
     
@@ -276,11 +271,11 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             });
 
             assertItem.importRegionAck2.map((Region, idxRegion) => {
-                describe(`Import "${assertItem.importRegion2[idxRegion].file}"`, () => {
+                describe(`Import "${assertItem.importRegion2[idxRegion].file}" from ${saveSubdirectory}`, () => {
                     let importRegionAck: any;
                     let importRegionAckProperties: any;
                     test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                        importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
+                        importRegionAck = await msgController.importRegion(saveSubdirectory,assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
                         
                         importRegionAckProperties = Object.keys(importRegionAck.regions);
                         if (importRegionAck.message != '') {

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -1,0 +1,308 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let regionSubdirectory = config.path.region;
+let connectTimeout = config.timeout.connection;
+let importTimeout = config.timeout.import;
+let exportTimeout = config.timeout.export;
+
+interface ImportRegionAckExt2 extends CARTA.IImportRegionAck {
+    lengthOfRegions?: number;
+    assertRegionId?: {
+        index: number,
+        id: number,
+    };
+};
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesRequire: CARTA.IAddRequiredTiles;
+    precisionDigits: number;
+    importRegion: CARTA.IImportRegion;
+    importRegionAck: CARTA.IImportRegionAck;
+    exportRegion: CARTA.IExportRegion[];
+    exportRegionAck: CARTA.IExportRegionAck[];
+    importRegion2: CARTA.IImportRegion[];
+    importRegionAck2: ImportRegionAckExt2[];
+};
+let assertItem: AssertItem = {
+    openFile:
+    {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+    },
+    addTilesRequire:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    precisionDigits: 4,
+    importRegion:
+    {
+        contents: [],
+        // directory: regionSubdirectory,
+        file: "M17_SWex_testRegions_pix.reg",
+        groupId: 0,
+        type: CARTA.FileType.DS9_REG,
+    },
+    importRegionAck:
+    {
+        success: true,
+        regions: {
+            '1': {
+                controlPoints: [{ x: 319, y: 399 }, { x: 40, y: 100 }],
+                regionType: CARTA.RegionType.RECTANGLE,
+            },
+            '2': {
+                controlPoints: [{ x: 319, y: 399 }, { x: 100, y: 40 }],
+                regionType: CARTA.RegionType.RECTANGLE,
+            },
+            '3': {
+                controlPoints: [{ x: 319, y: 399 }, { x: 200, y: 40 }],
+                rotation: 45,
+                regionType: CARTA.RegionType.RECTANGLE,
+            },
+            '4': {
+                controlPoints: [{ x: 319, y: 399 }, { x: 319, y: 599 }, { x: 399, y: 399 }],
+                regionType: CARTA.RegionType.POLYGON,
+            },
+            '5': {
+                controlPoints: [{ x: 319, y: 399 }, { x: 200, y: 200 }],
+                regionType: CARTA.RegionType.ELLIPSE,
+            },
+            '6': {
+                controlPoints: [{ x: 319, y: 399 }, { x: 100, y: 20 }],
+                regionType: CARTA.RegionType.ELLIPSE,
+                rotation: 45,
+            },
+            '7': {
+                controlPoints: [{ x: 319, y: 299 }],
+                regionType: CARTA.RegionType.POINT,
+            },
+        },
+        regionStyles: {
+            '1': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '2': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '3': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '4': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '5': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '6': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+            '7': { color: "#2EE6D6", dashList: [], lineWidth: 1, name: "" },
+        },
+    },
+    exportRegion:
+        [
+            {
+                coordType: CARTA.CoordinateType.WORLD,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_world.reg",
+                fileId: 0,
+                type: CARTA.FileType.DS9_REG,
+                regionStyles: {
+                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                },
+                // regionId: [1, 2, 3, 4, 5, 6, 7],
+            },
+            {
+                coordType: CARTA.CoordinateType.PIXEL,
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_pix.reg",
+                fileId: 0,
+                type: CARTA.FileType.DS9_REG,
+                // regionId: [1, 2, 3, 4, 5, 6, 7],
+                regionStyles: {
+                    '1': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '2': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '3': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '4': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '5': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '6': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                    '7': { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" },
+                }
+            },
+        ],
+    exportRegionAck:
+        [
+            {
+                success: true,
+                contents: [],
+            },
+            {
+                success: true,
+                contents: [],
+            },
+        ],
+    importRegion2:
+        [
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_world.reg",
+                groupId: 0,
+                type: CARTA.FileType.DS9_REG,
+            },
+            {
+                contents: [],
+                // directory: regionSubdirectory,
+                file: "M17_SWex_testRegions_pix_export_to_pix.reg",
+                groupId: 0,
+                type: CARTA.FileType.DS9_REG,
+            },
+        ],
+    importRegionAck2:
+        [
+            {
+                success: true,
+                lengthOfRegions: 7,
+                assertRegionId: {
+                    index: 6,
+                    id: 14,
+                },
+            },
+            {
+                success: true,
+                lengthOfRegions: 7,
+                assertRegionId: {
+                    index: 6,
+                    id: 21,
+                },
+            },
+        ],
+};
+
+let basepath: string;
+describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+            test(`Preparation: Open image`,async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesRequire);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            describe(`Import "${assertItem.importRegion.file}"`, () => {
+                let importRegionAck: any;
+                let importRegionAckProperties: any[];
+                test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                    importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion.file, assertItem.importRegion.type, assertItem.importRegion.groupId )
+                    importRegionAckProperties = Object.keys(importRegionAck.regions);
+                    if (importRegionAck.message != '') {
+                        console.warn(importRegionAck.message);
+                    }
+                }, importTimeout);
+    
+                test(`IMPORT_REGION_ACK.success = ${assertItem.importRegionAck.success}`, () => {
+                    expect(importRegionAck.success).toBe(assertItem.importRegionAck.success);
+                });
+    
+                test(`Length of IMPORT_REGION_ACK.region = ${Object.keys(assertItem.importRegionAck.regions).length}`, () => {
+                    expect(importRegionAckProperties.length).toEqual(Object.keys(assertItem.importRegionAck.regions).length);
+                });
+    
+                Object.keys(assertItem.importRegionAck.regions).map((region, index) => {
+                    test(`IMPORT_REGION_ACK.region[${index}] = "Id:${region}, Type:${CARTA.RegionType[assertItem.importRegionAck.regions[region].regionType]}"`, () => {
+                        expect(importRegionAckProperties[index]).toEqual(String(region));
+                        expect(importRegionAck.regions[importRegionAckProperties[index]].regionType).toEqual(assertItem.importRegionAck.regions[region].regionType);
+                        if (assertItem.importRegionAck.regions[region].rotation)
+                            expect(importRegionAck.regions[importRegionAckProperties[index]].rotation).toEqual(assertItem.importRegionAck.regions[region].rotation);
+                        expect(importRegionAck.regions[importRegionAckProperties[index]].controlPoints).toEqual(assertItem.importRegionAck.regions[region].controlPoints);
+                    });
+                });
+            });
+
+            assertItem.exportRegionAck.map((exRegion, idxRegion) => {
+                describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
+                    let exportRegionAck: any;
+                    test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        let regionStyle = new Map<number, CARTA.IRegionStyle>().set(1, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(2, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(3, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(4, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(5, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(6, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(7, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+                        regionStyle.set(8, { color: "#2EE6D6", dashList: [], lineWidth: 2, name: "" });
+
+                        assertItem.exportRegion[idxRegion].directory = basepath + "/" + regionSubdirectory; 
+                        exportRegionAck = await msgController.exportRegion(assertItem.exportRegion[idxRegion].directory, assertItem.exportRegion[idxRegion].file, assertItem.exportRegion[idxRegion].type, assertItem.exportRegion[idxRegion].coordType, assertItem.exportRegion[idxRegion].fileId, regionStyle);
+                    }, exportTimeout);
+    
+                    test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
+                        expect(exportRegionAck.success).toBe(exRegion.success);
+                    });
+    
+                    test(`EXPORT_REGION_ACK.contents = ${JSON.stringify(exRegion.contents)}`, () => {
+                        expect(exportRegionAck.contents).toEqual(exRegion.contents);
+                    });
+                });
+            });
+
+            assertItem.importRegionAck2.map((Region, idxRegion) => {
+                describe(`Import "${assertItem.importRegion2[idxRegion].file}"`, () => {
+                    let importRegionAck: any;
+                    let importRegionAckProperties: any;
+                    test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
+                        importRegionAck = await msgController.importRegion(basepath + "/" + regionSubdirectory,assertItem.importRegion2[idxRegion].file, assertItem.importRegion2[idxRegion].type, assertItem.importRegion2[idxRegion].groupId )
+                        
+                        importRegionAckProperties = Object.keys(importRegionAck.regions);
+                        if (importRegionAck.message != '') {
+                            console.warn(importRegionAck.message);
+                        }
+                    }, importTimeout);
+    
+                    test(`IMPORT_REGION_ACK.success = ${Region.success}`, () => {
+                        expect(importRegionAck.success).toBe(Region.success);
+                    });
+    
+                    test(`Length of IMPORT_REGION_ACK.regions = ${Region.lengthOfRegions}`, () => {
+                        expect(importRegionAckProperties.length).toEqual(Region.lengthOfRegions);
+                    });
+    
+                    test(`IMPORT_REGION_ACK.regions[${Region.assertRegionId.index}].region_id = ${Region.assertRegionId.id}`, () => {
+                        expect(importRegionAckProperties[importRegionAckProperties.length - 1]).toEqual(String(Region.assertRegionId.id));
+                    });
+                });
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/FILEINFO_EXCEPTIONS.test.ts
+++ b/src/test/FILEINFO_EXCEPTIONS.test.ts
@@ -1,0 +1,57 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let listFileTimeout = config.timeout.listFile;
+let openFileTimeout = config.timeout.openFile;
+
+interface AssertItem {
+    message: string[];
+};
+
+let assertItem: AssertItem = {
+    message: [
+        "File no_such_file.image does not exist.",
+        "Image must be 2D, 3D or 4D."
+    ]
+};
+
+let basepath: string;
+describe("FILEINFO_EXCEPTIONS: Testing error handle of file info generation", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        describe(`Go to "${testSubdirectory}" folder`, () => {
+            test('Preparation:',async () => {
+                let FileListResponse = await msgController.getFileList('$BASE', 0);
+                basepath = FileListResponse.directory;
+            }, listFileTimeout);
+        });
+
+        ["no_such_file.image", "broken_header.miriad"].map((fileName: string, index) => {
+            describe(`query the info of file : ${fileName}`, () => {
+                test(`FILE_INFO_RESPONSE should arrive within ${openFileTimeout} ms" and check the message`, async () => {
+                    // const data = await msgController.getFileInfo(`${basepath}/` + testSubdirectory, fileName, "0")
+                    
+                    // .then((data) => {console.log(data)})
+                    // .catch((err) => console.log(err))
+                    try {
+                        await msgController.getFileInfo(`${basepath}/` + testSubdirectory, fileName, "0");
+                    } catch (err) {
+                        console.log(err);
+                        expect(err).toEqual(assertItem.message[index])
+                    }
+                }, openFileTimeout);
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/FILEINFO_FITS_MULTIHDU.test.ts
+++ b/src/test/FILEINFO_FITS_MULTIHDU.test.ts
@@ -1,0 +1,455 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let listFileTimeout = config.timeout.listFile;
+let openFileTimeout = config.timeout.openFile;
+
+interface AssertItem {
+    headerCount: number;
+    fileInfoRequest: CARTA.IFileInfoRequest;
+    fileInfoExtendedString: string[];
+    fileInfoResponse: CARTA.IFileInfoResponse;
+};
+
+let assertItem: AssertItem = {
+    headerCount: 53,
+    fileInfoRequest: {
+        file: "spire500_ext.fits",
+        hdu: "",
+    },
+    fileInfoExtendedString: ['1','6','7'],
+    fileInfoResponse: {
+        success: true,
+        message: "",
+        fileInfo: {
+            name: "spire500_ext.fits",
+            type: CARTA.FileType.FITS,
+            size: 17591040,
+            HDUList: [""],
+        },
+        fileInfoExtended: {
+            '1': {
+                dimensions: 2,
+                width: 830,
+                height: 870,
+                depth: 1,
+                stokes: 1,
+                stokesVals: [],
+                computedEntries: [
+                    { name: "Name", value: "spire500_ext.fits" },
+		    { name: "Data type", value: "double" },
+                    { name: 'HDU', value: '1' },
+                    { name: 'Extension name', value: 'image' },
+                    { name: "Shape", value: "[830, 870]" },
+                    { name: "Coordinate type", value: "Right Ascension, Declination" },
+                    { name: "Projection", value: "TAN" },
+                    { name: "Image reference pixels", value: "[371, 421]" },
+                    { name: "Image reference coords", value: "[07:09:13.1081, -010.36.38.5952]" },
+                    { name: "Image ref coords (deg)", value: "[107.305 deg, -10.6107 deg]" },
+                    { name: "Celestial frame", value: "FK5, J2000" },
+                    { name: "Pixel unit", value: "MJy/sr" },
+                    { name: "Pixel increment", value: "-14\", 14\"" },
+                    { name: "RA range", value: "[07:01:55.064, 07:15:06.258]" },
+                    { name: "DEC range", value: "[-12.14.22.907, -08.51.38.954]" },
+                ],
+                headerEntries: [
+                    { name: "XTENSION", value: "IMAGE", comment: ' Java FITS: Wed Oct 01 10:15:59 CEST 2014' },
+                    { name: "BITPIX", value: "-64", entryType: 2, numericValue: -64 },
+                    { name: "NAXIS", value: "2", entryType: 2, numericValue: 2 },
+                    { name: "NAXIS1", value: "830", entryType: 2, numericValue: 830 },
+                    { name: "NAXIS2", value: "870", entryType: 2, numericValue: 870 },
+                    { name: "PCOUNT", value: "0", entryType: 2, comment: " No extra parameters"},
+                    { name: "GCOUNT", value: "1", entryType: 2, numericValue:1, comment: " One group"},
+                    { name: "LONGSTRN", value: "OGIP 1.0", comment: " The OGIP long string convention may be used."},
+                    { name: "EXTNAME", value: "image", comment: " name of this HDU"},
+                    { name: "CLASS___", value: "herschel.ia.dataset.ArrayDataset", comment: " java representation" },
+                    { name: "INFO____", value: "Image" },
+                    { name: "DATA____", value: "herschel.ia.numeric.Double2d", comment:" java Data" },
+                    { name: "QTTY____", value: "MJy/sr", comment:" Unit of the data" },
+                    { name: "BUNIT", value: "MJy/sr", comment: ' Unit of the data' },
+                    {
+                        name: "META_0",
+                        value: "2",
+                        entryType: 2,
+                        numericValue: 2,
+                        comment: " [] WCS: Number of Axes"
+                    },
+                    { name: "CRPIX1", value: "371", entryType: 1, numericValue: 371 },
+                    { name: "CRPIX2", value: "421", entryType: 1, numericValue: 421 },
+                    {
+                        name: "CRVAL1",
+                        value: "1.073046172702E+02",
+                        entryType: 1,
+                        numericValue: 107.30461727023817
+                    },
+                    {
+                        name: "CRVAL2",
+                        value: "-1.061072089652E+01",
+                        entryType: 1,
+                        numericValue: -10.610720896516849
+                    },
+                    {
+                        name: "CDELT1",
+                        value: "-3.888888888889E-03",
+                        entryType: 1,
+                        numericValue: -0.003888888888889
+                    },
+                    {
+                        name: "CDELT2",
+                        value: "3.888888888889E-03",
+                        entryType: 1,
+                        numericValue: 0.003888888888889
+                    },
+                    { name: "CTYPE1", value: "RA---TAN" },
+                    { name: "CTYPE2", value: "DEC--TAN" },
+                    {
+                        name: "EQUINOX",
+                        value: "2000",
+                        entryType: 1,
+                        numericValue: 2000
+                    },
+                    {
+                        name: "CROTA2",
+                        value: "0.000000000000E+00",
+                        entryType: 1,
+                        comment: " [] The Rotation angle"
+                    },
+                    {
+                        name: "META_1",
+                        value: "830",
+                        entryType: 2,
+                        numericValue: 830
+                    },
+                    {
+                        name: "META_2",
+                        value: "870",
+                        entryType: 2,
+                        numericValue: 870
+                    },
+                ],
+            },
+            '6': {
+                dimensions: 2,
+                width: 830,
+                height: 870,
+                depth: 1,
+                stokes: 1,
+                stokesVals: [],
+                computedEntries: [
+                    { name: "Name", value: "spire500_ext.fits" },
+		    { name: "Data type", value: "double" },
+                    { name: 'HDU', value: '6' },
+                    { name: 'Extension name', value: 'error' },
+                    { name: "Shape", value: "[830, 870]" },
+                    { name: "Coordinate type", value: "Right Ascension, Declination" },
+                    { name: "Projection", value: "TAN" },
+                    { name: "Image reference pixels", value: "[371, 421]" },
+                    { name: "Image reference coords", value: "[07:09:13.1081, -010.36.38.5952]" },
+                    { name: "Image ref coords (deg)", value: "[107.305 deg, -10.6107 deg]" },
+                    { name: "Celestial frame", value: "FK5, J2000" },
+                    { name: "Pixel unit", value: "MJy/sr" },
+                    { name: "Pixel increment", value: "-14\", 14\"" },
+                    { name: "RA range", value: "[07:01:55.064, 07:15:06.258]" },
+                    { name: "DEC range", value: "[-12.14.22.907, -08.51.38.954]" },
+                ],
+                headerEntries: [
+                    { name: "XTENSION", value: "IMAGE", comment: ' Java FITS: Wed Oct 01 10:15:59 CEST 2014' },
+                    { name: "BITPIX", value: "-64", entryType: 2, numericValue: -64 },
+                    { name: "NAXIS", value: "2", entryType: 2, numericValue: 2 },
+                    { name: "NAXIS1", value: "830", entryType: 2, numericValue: 830 },
+                    { name: "NAXIS2", value: "870", entryType: 2, numericValue: 870 },
+                    { name: "PCOUNT", value: "0", entryType: 2, comment: " No extra parameters"},
+                    { name: "GCOUNT", value: "1", entryType: 2, numericValue:1, comment: " One group"},
+                    { name: "LONGSTRN", value: "OGIP 1.0", comment: " The OGIP long string convention may be used."},
+                    { name: "EXTNAME", value: "error", comment: " name of this HDU"},
+                    { name: "CLASS___", value: "herschel.ia.dataset.ArrayDataset", comment: " java representation" },
+                    { name: "INFO____", value: "Statistical error on the pixel values" },
+                    { name: "DATA____", value: "herschel.ia.numeric.Double2d", comment:" java Data" },
+                    { name: "QTTY____", value: "MJy/sr", comment:" Unit of the data" },
+                    { name: "BUNIT", value: "MJy/sr", comment: ' Unit of the data' },
+                    {
+                        name: "META_0",
+                        value: "2",
+                        entryType: 2,
+                        numericValue: 2,
+                        comment: " [] WCS: Number of Axes"
+                    },
+                    { name: "CRPIX1", value: "371", entryType: 1, numericValue: 371 },
+                    { name: "CRPIX2", value: "421", entryType: 1, numericValue: 421 },
+                    {
+                        name: "CRVAL1",
+                        value: "1.073046172702E+02",
+                        entryType: 1,
+                        numericValue: 107.30461727023817
+                    },
+                    {
+                        name: "CRVAL2",
+                        value: "-1.061072089652E+01",
+                        entryType: 1,
+                        numericValue: -10.610720896516849
+                    },
+                    {
+                        name: "CDELT1",
+                        value: "-3.888888888889E-03",
+                        entryType: 1,
+                        numericValue: -0.003888888888889
+                    },
+                    {
+                        name: "CDELT2",
+                        value: "3.888888888889E-03",
+                        entryType: 1,
+                        numericValue: 0.003888888888889
+                    },
+                    { name: "CTYPE1", value: "RA---TAN" },
+                    { name: "CTYPE2", value: "DEC--TAN" },
+                    {
+                        name: "EQUINOX",
+                        value: "2000",
+                        entryType: 1,
+                        numericValue: 2000
+                    },
+                    {
+                        name: "CROTA2",
+                        value: "0.000000000000E+00",
+                        entryType: 1,
+                        comment: " [] The Rotation angle"
+                    },
+                    {
+                        name: "META_1",
+                        value: "830",
+                        entryType: 2,
+                        numericValue: 830
+                    },
+                    {
+                        name: "META_2",
+                        value: "870",
+                        entryType: 2,
+                        numericValue: 870
+                    },
+                ],
+            },
+            '7': {
+                dimensions: 2,
+                width: 830,
+                height: 870,
+                depth: 1,
+                stokes: 1,
+                stokesVals: [],
+                computedEntries: [
+                    { name: "Name", value: "spire500_ext.fits" },
+		    { name: "Data type", value: "double" },
+                    { name: 'HDU', value: '7' },
+                    { name: 'Extension name', value: 'coverage' },
+                    { name: "Shape", value: "[830, 870]" },
+                    { name: "Coordinate type", value: "Right Ascension, Declination" },
+                    { name: "Projection", value: "TAN" },
+                    { name: "Image reference pixels", value: "[371, 421]" },
+                    { name: "Image reference coords", value: "[07:09:13.1081, -010.36.38.5952]" },
+                    { name: "Image ref coords (deg)", value: "[107.305 deg, -10.6107 deg]" },
+                    { name: "Celestial frame", value: "FK5, J2000" },
+                    { name: "Pixel unit", value: "1" },
+                    { name: "Pixel increment", value: "-14\", 14\"" },
+                    { name: "RA range", value: "[07:01:55.064, 07:15:06.258]" },
+                    { name: "DEC range", value: "[-12.14.22.907, -08.51.38.954]" },
+                ],
+                headerEntries: [
+                    { name: "XTENSION", value: "IMAGE", comment: ' Java FITS: Wed Oct 01 10:15:59 CEST 2014' },
+                    { name: "BITPIX", value: "-64", entryType: 2, numericValue: -64 },
+                    { name: "NAXIS", value: "2", entryType: 2, numericValue: 2 },
+                    { name: "NAXIS1", value: "830", entryType: 2, numericValue: 830 },
+                    { name: "NAXIS2", value: "870", entryType: 2, numericValue: 870 },
+                    { name: "PCOUNT", value: "0", entryType: 2, comment: " No extra parameters"},
+                    { name: "GCOUNT", value: "1", entryType: 2, numericValue:1, comment: " One group"},
+                    { name: "LONGSTRN", value: "OGIP 1.0", comment: " The OGIP long string convention may be used."},
+                    { name: "EXTNAME", value: "coverage", comment: " name of this HDU"},
+                    { name: "CLASS___", value: "herschel.ia.dataset.ArrayDataset", comment: " java representation" },
+                    { name: "INFO____", value: "Coverage" },
+                    { name: "DATA____", value: "herschel.ia.numeric.Double2d", comment:" java Data" },
+                    { name: "QTTY____", value: "1", comment:" Unit of the data" },
+                    { name: "BUNIT", value: "1", comment: ' Unit of the data' },
+                    {
+                        name: "META_0",
+                        value: "2",
+                        entryType: 2,
+                        numericValue: 2,
+                        comment: " [] WCS: Number of Axes"
+                    },
+                    { name: "CRPIX1", value: "371", entryType: 1, numericValue: 371 },
+                    { name: "CRPIX2", value: "421", entryType: 1, numericValue: 421 },
+                    {
+                        name: "CRVAL1",
+                        value: "1.073046172702E+02",
+                        entryType: 1,
+                        numericValue: 107.30461727023817
+                    },
+                    {
+                        name: "CRVAL2",
+                        value: "-1.061072089652E+01",
+                        entryType: 1,
+                        numericValue: -10.610720896516849
+                    },
+                    {
+                        name: "CDELT1",
+                        value: "-3.888888888889E-03",
+                        entryType: 1,
+                        numericValue: -0.003888888888889
+                    },
+                    {
+                        name: "CDELT2",
+                        value: "3.888888888889E-03",
+                        entryType: 1,
+                        numericValue: 0.003888888888889
+                    },
+                    { name: "CTYPE1", value: "RA---TAN" },
+                    { name: "CTYPE2", value: "DEC--TAN" },
+                    {
+                        name: "EQUINOX",
+                        value: "2000",
+                        entryType: 1,
+                        numericValue: 2000
+                    },
+                    {
+                        name: "CROTA2",
+                        value: "0.000000000000E+00",
+                        entryType: 1,
+                        comment: " [] The Rotation angle"
+                    },
+                    {
+                        name: "META_1",
+                        value: "830",
+                        entryType: 2,
+                        numericValue: 830
+                    },
+                    {
+                        name: "META_2",
+                        value: "870",
+                        entryType: 2,
+                        numericValue: 870
+                    },
+                ],
+            },
+        },
+    },
+};
+
+let basepath: string;
+describe("FILEINFO_FITS_MULTIHDU: Testing if info of an FITS image file is correctly delivered by the backend", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        describe(`Go to "${testSubdirectory}" folder`, () => {
+            test('Preparation:',async () => {
+                let FileListResponse = await msgController.getFileList('$BASE', 0);
+                basepath = FileListResponse.directory;
+            }, listFileTimeout);
+        });
+
+        describe(`query the info of file : ${assertItem.fileInfoRequest.file}`, () => {
+            let FileInfoResponse: any;
+            test(`FILE_INFO_RESPONSE should arrive within ${openFileTimeout} ms".`, async () => {
+                FileInfoResponse = await msgController.getFileInfo(`${basepath}/` + testSubdirectory, assertItem.fileInfoRequest.file, assertItem.fileInfoRequest.hdu)
+            }, openFileTimeout);
+
+            test("FILE_INFO_RESPONSE.success = true", () => {
+                expect(FileInfoResponse.success).toBe(true);
+            });
+
+            test(`FILE_INFO_RESPONSE.file_info.HDU_List = [${assertItem.fileInfoResponse.fileInfo.HDUList}]`, () => {
+                assertItem.fileInfoResponse.fileInfo.HDUList.map((entry, index) => {
+                    expect(FileInfoResponse.fileInfo.HDUList).toContainEqual(entry);
+                });
+            });
+
+            test(`FILE_INFO_RESPONSE.file_info.name = "${assertItem.fileInfoResponse.fileInfo.name}"`, () => {
+                expect(FileInfoResponse.fileInfo.name).toEqual(assertItem.fileInfoResponse.fileInfo.name);
+            });
+
+            test(`FILE_INFO_RESPONSE.file_info.size = ${assertItem.fileInfoResponse.fileInfo.size}`, () => {
+                expect(FileInfoResponse.fileInfo.size.toString()).toEqual(assertItem.fileInfoResponse.fileInfo.size.toString());
+            });
+
+            test(`FILE_INFO_RESPONSE.file_info.type = ${CARTA.FileType.FITS}`, () => {
+                expect(FileInfoResponse.fileInfo.type).toBe(assertItem.fileInfoResponse.fileInfo.type);
+            });
+
+            assertItem.fileInfoExtendedString.map((input, index) => {
+                describe(`FileInfoExtended of '${input}':`, () => {
+                    test(`FILE_INFO_RESPONSE.file_info_extended.dimensions = ${assertItem.fileInfoResponse.fileInfoExtended[input].dimensions}`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].dimensions).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].dimensions);
+                    });
+
+                    test(`FILE_INFO_RESPONSE.file_info_extended.width = ${assertItem.fileInfoResponse.fileInfoExtended[input].width}`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].width).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].width);
+                    });
+
+                    test(`FILE_INFO_RESPONSE.file_info_extended.height = ${assertItem.fileInfoResponse.fileInfoExtended[input].height}`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].height).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].height);
+                    });
+
+                    if (assertItem.fileInfoResponse.fileInfoExtended[input].dimensions >= 2) {
+                        test(`FILE_INFO_RESPONSE.file_info_extended.depth = ${assertItem.fileInfoResponse.fileInfoExtended[input].depth}`, () => {
+                            expect(FileInfoResponse.fileInfoExtended[input].depth).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].depth);
+                        });
+                    };
+
+                    if (assertItem.fileInfoResponse.fileInfoExtended[input].dimensions >= 2) {
+                        test(`FILE_INFO_RESPONSE.file_info_extended.stokes = ${assertItem.fileInfoResponse.fileInfoExtended[input].stokes}`, () => {
+                            expect(FileInfoResponse.fileInfoExtended[input].stokes).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].stokes);
+                        });
+                    };
+
+                    test(`FILE_INFO_RESPONSE.file_info_extended.stokes_vals = [${assertItem.fileInfoResponse.fileInfoExtended[input].stokesVals}]`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].stokesVals).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].stokesVals);
+                    });
+
+                    test(`len(FILE_INFO_RESPONSE.file_info_extended.computed_entries)==${assertItem.fileInfoResponse.fileInfoExtended[input].computedEntries.length}`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].computedEntries.length).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].computedEntries.length);
+                    });
+
+                    test(`assert FILE_INFO_RESPONSE.file_info_extended.computed_entries`, () => {
+                        assertItem.fileInfoResponse.fileInfoExtended[input].computedEntries.map((entry: CARTA.IHeaderEntry, index) => {
+                            if (isNaN(parseFloat(entry.value))){
+                                expect(FileInfoResponse.fileInfoExtended[input].computedEntries.find(f => f.name == entry.name).value).toEqual(entry.value);
+                            } else {
+                                expect(parseFloat(FileInfoResponse.fileInfoExtended[input].computedEntries.find(f => f.name == entry.name).value)).toEqual(parseFloat(entry.value));
+                            }
+                            expect(FileInfoResponse.fileInfoExtended[input].computedEntries.find(f => f.name == entry.name).value).toEqual(entry.value);
+                        });
+                    });
+
+                    test(`len(file_info_extended.header_entries)==${assertItem.headerCount}`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].headerEntries.length).toEqual(assertItem.headerCount)
+                    });
+
+                    test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {
+                        let FileInfoResponse_value = [];
+                        FileInfoResponse.fileInfoExtended[input].headerEntries.map((f) => {
+                            let keysNum = Object.keys(f).length;
+                            if (keysNum > 1) {
+                                FileInfoResponse_value.push(f)
+                            };
+                        });
+
+                        assertItem.fileInfoResponse.fileInfoExtended[input].headerEntries.map((entry: CARTA.IHeaderEntry, index) => {
+                            if (isNaN(parseFloat(entry.value))){
+                                expect(FileInfoResponse_value.find(f => f.name == entry.name).value).toEqual(entry.value);
+                            } else {
+                                expect(parseFloat(FileInfoResponse_value.find(f => f.name == entry.name).value)).toEqual(parseFloat(entry.value));
+                            }
+                        });
+                    });
+                });
+            })
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts
+++ b/src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts
@@ -1,0 +1,65 @@
+import { CARTA } from "carta-protobuf";
+import { BackendService } from "./MessageController-concurrent";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let expectRootPath = config.path.root;
+let testNumber = config.repeat.concurrent;
+
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: {
+        directory: config.path.base,
+    },
+}
+let client: BackendService[] = Array(testNumber);
+let fileListResponse: any[] = new Array(testNumber);
+describe("GET_FILELIST_ROOTPATH_CONCURRENT test: Testing generation of a file list at root path from multiple concurrent users.", () => {
+    for (let i = 0; i< client.length; i++) {
+        describe(`establish #${i} connections to "${testServerUrl}`, () => {
+            test(`Ask RegisterViewerAck:`, async() => {
+                client[i] = new BackendService;
+                await client[i].connect(testServerUrl);
+            });
+
+            test(`Ask FileListResponse`, async()=>{
+                fileListResponse[i] = await client[i].getFileList('$BASE', 0);
+            })
+
+            test(`assert every FILE_LIST_RESPONSE.success to be True.`, () => {
+                expect(fileListResponse[i].success).toBe(true);
+            })
+
+            // test(`assert every FILE_LIST_RESPONSE.parent is None.`, () => {
+            //     expect(fileListResponse[i].parent).toBe(""); 
+            // });
+
+            // test(`assert every FILE_LIST_RESPONSE.directory is "${expectRootPath}".`, () => {
+            //     expect(fileListResponse[i].directory).toBe(expectRootPath);
+            // });
+
+            test(`assert all FILE_LIST_RESPONSE.files[] are identical.`, () => {
+                expect(fileListResponse[0]).toBeDefined();
+                expect(JSON.stringify(fileListResponse[i].files)).toEqual(JSON.stringify(fileListResponse[0].files))
+            });
+
+            test(`assert all FILE_LIST_RESPONSE.subdirectories[] are identical.`, () => {
+                expect(fileListResponse[0]).toBeDefined();
+                expect(JSON.stringify(fileListResponse[i].subdirectories)).toEqual(JSON.stringify(fileListResponse[0].subdirectories))
+            });
+        })
+    }
+
+    afterAll( async () => {
+        for (let i = 0; i< client.length; i++) {
+            await client[i].closeConnection();
+        }
+    });
+});

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -1,0 +1,485 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { execSync } from "child_process";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let imageFittingTimeout: number = config.timeout.imageFitting;
+
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    fittingRequest: CARTA.IFittingRequest[];
+    fittingResponse: CARTA.IFittingResponse[];
+    fittingResponseMacOS110601: CARTA.IFittingResponse[];
+    fittingResponseMacOS12: CARTA.IFittingResponse[];
+    fittingResponseLinux: CARTA.IFittingResponse[];
+    fittingResponseUbuntu2204: CARTA.IFittingResponse[];
+    precisionDigits: number;
+};
+
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "ThreeComponent-inclined-2d-gaussian.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },    
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    fittingRequest: [
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: null,
+            regionId: -1, 
+            initialValues: [
+                {amp: 1, center: {x: 164, y: 280}, fwhm: {x: 100, y: 5}, pa: 270}, 
+                {amp: 1, center: {x: 220, y: 270}, fwhm: {x: 30, y: 100}, pa: 45}, 
+            ]
+        },
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: null,
+            regionId: -1, 
+            initialValues: [{amp: 10, center: {x: 1000, y: 280}, fwhm: {x: 100, y: 5}, pa: 270}]
+        }
+    ],
+    fittingResponse: [
+        {
+            resultValues: [
+                {
+                    center: {x: 137.4108664786717, y: 278.30044158477193}, 
+                    amp: 0.2970113045359871,
+                    fwhm: {x: -0.1892426922028161, y: 0.2257496773140682},
+                    pa: 270.38937779546336
+                }, 
+                {
+                    center: {x: 324.3493469406151, y: 324.34873891574335}, 
+                    amp: 9.99701377626984,
+                    fwhm: {x: 29.399853003901757, y: 117.49088485007636},
+                    pa: 0.5342821807532023
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {},
+                    fwhm: {},
+                },
+                {
+                    center: {x: 0.14270290674700617, y: 0.03926940295174565},
+                    amp: 0.011881771744524577,
+                    fwhm: {x: 0.045959932685532584, y: 0.18286860946141664},
+                    pa: 0.0049460116505525625
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 2 component',
+            message: 'exceeded max number of iterations'
+        },
+        {
+            resultValues: [],
+            resultErrors: [],
+            success: true,
+            message: 'fit did not converge'
+        }
+    ],
+    fittingResponseMacOS110601:  [
+        {
+            resultValues: [
+                {
+                    center: {x: 101.25754777255497, y: 289.50143388893946}, 
+                    amp: 0.20980810056293095,
+                    fwhm: {x: 4.831878951840909, y: -0.13027624912739558},
+                    pa: 270.12676256733675
+                }, 
+                {
+                    center: {x: 324.34784293804995, y: 324.3488176351443}, 
+                    amp: 9.995468914523238,
+                    fwhm: {x: 29.399978883356663, y: 117.51285901668908},
+                    pa: 0.5307253505485405
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {},
+                    fwhm: {},
+                },
+                {
+                    center: {x: 0.1423816628460514, y: 0.03918068073755874},
+                    amp: 0.0116739400572081767,
+                    fwhm: {x: 0.04547626539798418, y: 0.1796625783242974},
+                    pa: 0.005286464774864215
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 2 component',
+            message: 'exceeded max number of iterations'
+        },
+        {
+            resultValues: [],
+            resultErrors: [],
+            success: true,
+            message: 'fit did not converge'
+        }
+    ],
+    fittingResponseMacOS12: [
+        {
+            resultValues: [
+                {
+                    center: {x: 129.52934425744016, y: 285.4183410816301}, 
+                    amp: 0.4657574006276674,
+                    fwhm: {x: -1.0178734138400989, y: 0.0643954893477044},
+                    pa: 356.65196671978725
+                }, 
+                {
+                    center: {x: 324.3426307770264, y: 324.34813278164734}, 
+                    amp: 9.995057596365545,
+                    fwhm: {x: 29.40129200278109, y: 117.49460686897025},
+                    pa: 0.5241778093682095
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {},
+                    fwhm: {},
+                },
+                {
+                    center: {x: 0.14270290674700617, y: 0.03926940295174565},
+                    amp: 0.011881771744524577,
+                    fwhm: {x: 0.045959932685532584, y: 0.18286860946141664},
+                    pa: 0.0049460116505525625
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 2 component',
+            message: 'exceeded max number of iterations'
+        },
+        {
+            resultValues: [],
+            resultErrors: [],
+            success: true,
+            message: 'fit did not converge'
+        }
+    ],
+    fittingResponseLinux: [
+        {
+            resultValues: [
+                {
+                    center: {x: 135.44304395891785, y: 279.2872847693339}, 
+                    amp: 0.3679796147238359,
+                    fwhm: {x: 0.10606045985196957, y: 0.28676758030525856},
+                    pa: 280.48905602819553
+                }, 
+                {
+                    center: {x: 324.3493469406151, y: 324.34873891574335}, 
+                    amp: 9.99701377626984,
+                    fwhm: {x: 29.399853003901757, y: 117.47343456730091},
+                    pa: 0.5291923527559826
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {},
+                    fwhm: {},
+                },
+                {
+                    center: {x: 0.14270290674700617, y: 0.03926940295174565},
+                    amp: 0.011881771744524577,
+                    fwhm: {x: 0.045959932685532584, y: 0.18286860946141664},
+                    pa: 0.0049460116505525625
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 2 component',
+            message: 'exceeded max number of iterations'
+        },
+        {
+            resultValues: [],
+            resultErrors: [],
+            success: true,
+            message: 'fit did not converge'
+        }
+    ],
+    fittingResponseUbuntu2204: [
+        {
+            resultValues: [
+                {
+                    center: {x: 141.19569242428403, y: 274.468080399765}, 
+                    amp: 0.0073312614530695805,
+                    fwhm: {x: 1.8888434341244704, y: 0.003414731271306315},
+                    pa: 289.1517791897806
+                }, 
+                {
+                    center: {x: 324.34387675503626, y: 324.3494127204754}, 
+                    amp: 9.995719972488988,
+                    fwhm: {x: 29.395209261545435, y: 117.53236329753543},
+                    pa: 0.5369662783821492
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {},
+                    fwhm: {},
+                },
+                {
+                    center: {x: 0.14270290674700617, y: 0.03926940295174565},
+                    amp: 0.011794239703922002,
+                    fwhm: {x: 0.045959932685532584, y: 0.18286860946141664},
+                    pa: 0.004197561925501329
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 2 component',
+            message: 'exceeded max number of iterations'
+        },
+        {
+            resultValues: [],
+            resultErrors: [],
+            success: true,
+            message: 'fit did not converge'
+        }
+    ],
+    precisionDigits: 2,
+};
+
+let platformOS: String;
+let MacOSNumber: any;
+let MacOSNumberResponse: any;
+let ubuntuNumber: any;
+let isUbunutu2204: boolean;
+let basepath: string;
+describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) with fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            let registerViewerAck = await msgController.connect(testServerUrl);
+            platformOS = registerViewerAck.platformStrings.platform;
+            if (platformOS === "macOS") {
+                MacOSNumberResponse = String(execSync('sw_vers -productVersion',{encoding: 'utf-8'}));
+                MacOSNumber = Number(MacOSNumberResponse.slice(0,2));
+                if (MacOSNumberResponse.toString().includes('11.6.1')) {
+                    MacOSNumber = '11.6.1';
+                }
+            }
+            if (platformOS === "Linux"){
+                let Response = String(execSync('lsb_release -a',{encoding: 'utf-8'}));
+                isUbunutu2204 = Response.includes("22.04");
+            }
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            describe(`(Step 0) Initialization: open the image`, () => {
+                test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                    msgController.closeFile(-1);
+                    msgController.closeFile(0);
+                    let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+    
+                test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                }, openFileTimeout);
+            });
+
+            
+        });
+
+        describe(`(Case 1) Image fitting: exceeded max number of iterations`, ()=>{
+            test(`Send Image fitting request and match the result`, async()=>{
+                let response = await msgController.requestFitting(assertItem.fittingRequest[0]);
+
+                if (MacOSNumber === "11.6.1" && platformOS === 'macOS') {
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.x).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.y).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].amp).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[1].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].pa).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultValues[1].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponseMacOS110601[0].success);
+
+                    expect(response.resultErrors[0].center.x).toEqual(0);
+                    expect(response.resultErrors[0].center.y).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.x).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.y).toEqual(0);
+                    expect(response.resultErrors[1].center.x).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultErrors[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].center.y).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultErrors[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].amp).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultErrors[1].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultErrors[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultErrors[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].pa).toBeCloseTo(assertItem.fittingResponseMacOS110601[0].resultErrors[1].pa, assertItem.precisionDigits);
+                
+                    expect(response.log).toContain(assertItem.fittingResponseMacOS110601[0].log);
+                    expect(response.message).toContain(assertItem.fittingResponseMacOS110601[0].message);
+                } else if (MacOSNumber === 12 && platformOS === 'macOS') {
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.x).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.y).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].amp).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[1].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].pa).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultValues[1].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponseMacOS12[0].success);
+
+                    expect(response.resultErrors[0].center.x).toEqual(0);
+                    expect(response.resultErrors[0].center.y).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.x).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.y).toEqual(0);
+                    expect(response.resultErrors[1].center.x).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultErrors[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].center.y).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultErrors[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].amp).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultErrors[1].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultErrors[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultErrors[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].pa).toBeCloseTo(assertItem.fittingResponseMacOS12[0].resultErrors[1].pa, assertItem.precisionDigits);
+                
+                    expect(response.log).toContain(assertItem.fittingResponseMacOS12[0].log);
+                    expect(response.message).toContain(assertItem.fittingResponseMacOS12[0].message);
+                } else if (platformOS === 'Linux' && isUbunutu2204 === false) {
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].amp).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[1].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].pa).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[1].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponseLinux[0].success);
+
+                    expect(response.resultErrors[0].center.x).toEqual(0);
+                    expect(response.resultErrors[0].center.y).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.x).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.y).toEqual(0);
+                    expect(response.resultErrors[1].center.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultErrors[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].center.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultErrors[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].amp).toBeCloseTo(assertItem.fittingResponseLinux[0].resultErrors[1].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultErrors[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultErrors[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].pa).toBeCloseTo(assertItem.fittingResponseLinux[0].resultErrors[1].pa, assertItem.precisionDigits);
+                
+                    expect(response.log).toContain(assertItem.fittingResponseLinux[0].log);
+                    expect(response.message).toContain(assertItem.fittingResponseLinux[0].message);
+                } else if (platformOS === 'Linux' && isUbunutu2204 === true) {
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].amp).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[1].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].pa).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[1].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponseUbuntu2204[0].success);
+
+                    expect(response.resultErrors[0].center.x).toEqual(0);
+                    expect(response.resultErrors[0].center.y).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.x).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.y).toEqual(0);
+                    expect(response.resultErrors[1].center.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultErrors[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].center.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultErrors[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].amp).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultErrors[1].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultErrors[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultErrors[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].pa).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultErrors[1].pa, assertItem.precisionDigits);
+                
+                    expect(response.log).toContain(assertItem.fittingResponseUbuntu2204[0].log);
+                    expect(response.message).toContain(assertItem.fittingResponseUbuntu2204[0].message);
+                } else {
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].amp).toBeCloseTo(assertItem.fittingResponse[0].resultValues[1].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[1].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[1].pa).toBeCloseTo(assertItem.fittingResponse[0].resultValues[1].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[0].success);
+
+                    expect(response.resultErrors[0].center.x).toEqual(0);
+                    expect(response.resultErrors[0].center.y).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.x).toEqual(0);
+                    expect(response.resultErrors[0].fwhm.y).toEqual(0);
+                    expect(response.resultErrors[1].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[1].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[1].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].amp).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[1].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[1].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[1].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[1].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[1].pa, assertItem.precisionDigits);
+                
+                    expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                    expect(response.message).toContain(assertItem.fittingResponse[0].message);
+                }
+            },imageFittingTimeout)
+        })
+
+        describe(`(Case 2) Image fitting: fit did not converge`, ()=>{
+            test(`Send Image fitting request and match the result`, async()=>{
+                try {
+                    await msgController.requestFitting(assertItem.fittingRequest[1])
+                } catch (err) {
+                    expect(err).toEqual(assertItem.fittingResponse[1].message)
+                }
+            },imageFittingTimeout)
+        })
+
+        test(`close file`, async () => {
+            msgController.closeFile(-1);
+        }, connectTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -51,7 +51,7 @@ let assertItem: AssertItem = {
     fittingRequest: [
         {
             fileId: 0,
-            fixedParams: [false, false, false, false, false, false],
+            fixedParams: [false, false, false, false, false, false, false, false, false, false, false, false],
             fovInfo: null,
             regionId: -1, 
             initialValues: [

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -269,7 +269,7 @@ let platformOS: String;
 let MacOSNumber: any;
 let MacOSNumberResponse: any;
 let ubuntuNumber: any;
-let isUbunutu2204: boolean;
+let isUbunutu2204orRedHat9: boolean;
 let basepath: string;
 describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) with fits file.", () => {
     const msgController = MessageController.Instance;
@@ -286,7 +286,7 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
             }
             if (platformOS === "Linux"){
                 let Response = String(execSync('lsb_release -a',{encoding: 'utf-8'}));
-                isUbunutu2204 = Response.includes("22.04");
+                isUbunutu2204orRedHat9 = Response.includes("22.04") || Response.includes("Red Hat Enterprise Linux 9.0");
             }
         }, connectTimeout);
 
@@ -378,7 +378,7 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                 
                     expect(response.log).toContain(assertItem.fittingResponseMacOS12[0].log);
                     expect(response.message).toContain(assertItem.fittingResponseMacOS12[0].message);
-                } else if (platformOS === 'Linux' && isUbunutu2204 === false) {
+                } else if (platformOS === 'Linux' && isUbunutu2204orRedHat9 === false) {
                     expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].center.x, assertItem.precisionDigits);
                     expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].center.y, assertItem.precisionDigits);
                     expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponseLinux[0].resultValues[0].amp, assertItem.precisionDigits);
@@ -406,7 +406,7 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                 
                     expect(response.log).toContain(assertItem.fittingResponseLinux[0].log);
                     expect(response.message).toContain(assertItem.fittingResponseLinux[0].message);
-                } else if (platformOS === 'Linux' && isUbunutu2204 === true) {
+                } else if (platformOS === 'Linux' && isUbunutu2204orRedHat9 === true) {
                     expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].center.x, assertItem.precisionDigits);
                     expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].center.y, assertItem.precisionDigits);
                     expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponseUbuntu2204[0].resultValues[0].amp, assertItem.precisionDigits);

--- a/src/test/IMAGE_FITTING_BAD.test.ts
+++ b/src/test/IMAGE_FITTING_BAD.test.ts
@@ -51,7 +51,7 @@ let assertItem: AssertItem = {
     fittingRequest: [
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: null,
             regionId: -1, 
             initialValues: [
@@ -61,7 +61,7 @@ let assertItem: AssertItem = {
         },
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: null,
             regionId: -1, 
             initialValues: [{amp: 10, center: {x: 1000, y: 280}, fwhm: {x: 100, y: 5}, pa: 270}]

--- a/src/test/IMAGE_FITTING_CASA.test.ts
+++ b/src/test/IMAGE_FITTING_CASA.test.ts
@@ -17,6 +17,8 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     fittingRequest: CARTA.IFittingRequest[];
     fittingResponse: CARTA.IFittingResponse[];
+    iterationNumber1: string;
+    iterationNumber2: string;
     precisionDigits: number;
 };
 
@@ -106,6 +108,8 @@ let assertItem: AssertItem = {
         }
     ],
     precisionDigits: 2,
+    iterationNumber1: 'number of iterations = 68',
+    iterationNumber2: 'number of iterations = 116' 
 };
 
 let basepath: string;
@@ -159,6 +163,7 @@ describe("IMAGE_FITTING_CASA test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                    expect(response.log).toContain(assertItem.iterationNumber1);
                 },imageFittingTimeout)
             })
 
@@ -180,6 +185,7 @@ describe("IMAGE_FITTING_CASA test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[1].log);
+                    expect(response.log).toContain(assertItem.iterationNumber2);
                 },imageFittingTimeout)
             })
         });

--- a/src/test/IMAGE_FITTING_CASA.test.ts
+++ b/src/test/IMAGE_FITTING_CASA.test.ts
@@ -1,0 +1,193 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let imageFittingTimeout: number = config.timeout.imageFitting;
+
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    fittingRequest: CARTA.IFittingRequest[];
+    fittingResponse: CARTA.IFittingResponse[];
+    precisionDigits: number;
+};
+
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "M17_SWex-channel0-addOneGaussian.image",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },    
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    fittingRequest: [
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: null,
+            regionId: -1, 
+            initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
+        },
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: {
+                controlPoints: [{x:319.5, y:399.5}, {x: 216.70644391408112, y: 199.99999999999997}],
+                regionType: 3,
+                rotation: 0,
+            },
+            regionId: 0, 
+            initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
+        }
+    ],
+    fittingResponse: [
+        {
+            resultValues: [
+                {
+                    center: {x: 319.4995814506346, y: 399.4997816490029}, 
+                    amp: 9.999559472737332,
+                    fwhm: {x: 170.63727122575295, y: 41.48182201673784},
+                    pa: 142.16266600131718
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {x: 0.0004006969240219716, y: 0.0005001794973076322},
+                    amp: 0.00003971187313364324,
+                    fwhm: {x: 0.0008773295469374465, y: 0.00021417449809861666},
+                    pa: 0.00020655506565535857
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 1 component'
+        },
+        {
+            resultValues: [
+                {
+                    center: {x: 319.498940837943, y: 399.4988615251924}, 
+                    amp: 9.999454722592997,
+                    fwhm: {x: 170.6382683676851, y: 41.48206117869241},
+                    pa: 142.16251357416306
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {x: 0.00010950493723812066, y: 0.0001246435132691238},
+                    amp: 0.000020566430029630594,
+                    fwhm: {x: 0.0004562033522657872, y: 0.00010502008093686605},
+                    pa: 0.00010562266856995906
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 1 component'
+        }
+    ],
+    precisionDigits: 2,
+};
+
+let basepath: string;
+describe("IMAGE_FITTING_CASA test: Testing Image Fitting (with and without fov) with casa file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            describe(`(Step 0) Initialization: open the image`, () => {
+                test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                    msgController.closeFile(-1);
+                    msgController.closeFile(0);
+                    let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+    
+                test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                }, openFileTimeout);
+            });
+
+            describe(`(Case 1) Image fitting without FoV:`, ()=>{
+                test(`Send Image fitting request and match the result`, async()=>{
+                    let response = await msgController.requestFitting(assertItem.fittingRequest[0]);
+                    
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[0].success);
+                    expect(response.resultErrors[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
+                    expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                },imageFittingTimeout)
+            })
+
+            describe(`(Case 2) Image fitting with FoV:`, ()=>{
+                test(`Send Image fitting request and match the result`, async()=>{
+                    let response = await msgController.requestFitting(assertItem.fittingRequest[1]);
+                    
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[1].success);
+                    expect(response.resultErrors[0].center.x).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].center.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].amp).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
+                    expect(response.log).toContain(assertItem.fittingResponse[1].log);
+                },imageFittingTimeout)
+            })
+        });
+
+        test(`close file`, async () => {
+            msgController.closeFile(-1);
+        }, connectTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/IMAGE_FITTING_CASA.test.ts
+++ b/src/test/IMAGE_FITTING_CASA.test.ts
@@ -17,8 +17,6 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     fittingRequest: CARTA.IFittingRequest[];
     fittingResponse: CARTA.IFittingResponse[];
-    iterationNumber1: string;
-    iterationNumber2: string;
     precisionDigits: number;
 };
 
@@ -48,14 +46,14 @@ let assertItem: AssertItem = {
     fittingRequest: [
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: null,
             regionId: -1, 
             initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
         },
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: {
                 controlPoints: [{x:319.5, y:399.5}, {x: 216.70644391408112, y: 199.99999999999997}],
                 regionType: 3,
@@ -108,8 +106,6 @@ let assertItem: AssertItem = {
         }
     ],
     precisionDigits: 2,
-    iterationNumber1: 'number of iterations = 68',
-    iterationNumber2: 'number of iterations = 116' 
 };
 
 let basepath: string;
@@ -163,7 +159,6 @@ describe("IMAGE_FITTING_CASA test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[0].log);
-                    expect(response.log).toContain(assertItem.iterationNumber1);
                 },imageFittingTimeout)
             })
 
@@ -185,7 +180,6 @@ describe("IMAGE_FITTING_CASA test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[1].log);
-                    expect(response.log).toContain(assertItem.iterationNumber2);
                 },imageFittingTimeout)
             })
         });

--- a/src/test/IMAGE_FITTING_FITS.test.ts
+++ b/src/test/IMAGE_FITTING_FITS.test.ts
@@ -17,8 +17,6 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     fittingRequest: CARTA.IFittingRequest[];
     fittingResponse: CARTA.IFittingResponse[];
-    iterationNumber1: string;
-    iterationNumber2: string;
     precisionDigits: number;
 };
 
@@ -48,14 +46,14 @@ let assertItem: AssertItem = {
     fittingRequest: [
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: null,
             regionId: -1, 
             initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
         },
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: {
                 controlPoints: [{x:319.5, y:399.5}, {x: 216.70644391408112, y: 199.99999999999997}],
                 regionType: 3,
@@ -108,8 +106,6 @@ let assertItem: AssertItem = {
         }
     ],
     precisionDigits: 2,
-    iterationNumber1: 'number of iterations = 68',
-    iterationNumber2: 'number of iterations = 116' 
 };
 
 let basepath: string;
@@ -163,7 +159,6 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[0].log);
-                    expect(response.log).toContain(assertItem.iterationNumber1);
                 },imageFittingTimeout)
             })
 
@@ -185,7 +180,6 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[1].log);
-                    expect(response.log).toContain(assertItem.iterationNumber2);
                 },imageFittingTimeout)
             })
         });

--- a/src/test/IMAGE_FITTING_FITS.test.ts
+++ b/src/test/IMAGE_FITTING_FITS.test.ts
@@ -1,0 +1,193 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let imageFittingTimeout: number = config.timeout.imageFitting;
+
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    fittingRequest: CARTA.IFittingRequest[];
+    fittingResponse: CARTA.IFittingResponse[];
+    precisionDigits: number;
+};
+
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "M17_SWex-channel0-addOneGaussian.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },    
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    fittingRequest: [
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: null,
+            regionId: -1, 
+            initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
+        },
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: {
+                controlPoints: [{x:319.5, y:399.5}, {x: 216.70644391408112, y: 199.99999999999997}],
+                regionType: 3,
+                rotation: 0,
+            },
+            regionId: 0, 
+            initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
+        }
+    ],
+    fittingResponse: [
+        {
+            resultValues: [
+                {
+                    center: {x: 319.4995814506346, y: 399.4997816490029}, 
+                    amp: 9.999559472737332,
+                    fwhm: {x: 170.63727122575295, y: 41.48182201673784},
+                    pa: 142.16266600131718
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {x: 0.0004006969240219716, y: 0.0005001794973076322},
+                    amp: 0.00003971187313364324,
+                    fwhm: {x: 0.0008773295469374465, y: 0.00021417449809861666},
+                    pa: 0.00020655506565535857
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 1 component'
+        },
+        {
+            resultValues: [
+                {
+                    center: {x: 319.498940837943, y: 399.4988615251924}, 
+                    amp: 9.999454722592997,
+                    fwhm: {x: 170.6382683676851, y: 41.48206117869241},
+                    pa: 142.16251357416306
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {x: 0.00010950493723812066, y: 0.0001246435132691238},
+                    amp: 0.000020566430029630594,
+                    fwhm: {x: 0.0004562033522657872, y: 0.00010502008093686605},
+                    pa: 0.00010562266856995906
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 1 component'
+        }
+    ],
+    precisionDigits: 2,
+};
+
+let basepath: string;
+describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) with fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            describe(`(Step 0) Initialization: open the image`, () => {
+                test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                    msgController.closeFile(-1);
+                    msgController.closeFile(0);
+                    let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+    
+                test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                }, openFileTimeout);
+            });
+
+            describe(`(Case 1) Image fitting without FoV:`, ()=>{
+                test(`Send Image fitting request and match the result`, async()=>{
+                    let response = await msgController.requestFitting(assertItem.fittingRequest[0]);
+                    
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[0].success);
+                    expect(response.resultErrors[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
+                    expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                },imageFittingTimeout)
+            })
+
+            describe(`(Case 2) Image fitting with FoV:`, ()=>{
+                test(`Send Image fitting request and match the result`, async()=>{
+                    let response = await msgController.requestFitting(assertItem.fittingRequest[1]);
+                    
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[1].success);
+                    expect(response.resultErrors[0].center.x).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].center.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].amp).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
+                    expect(response.log).toContain(assertItem.fittingResponse[1].log);
+                },imageFittingTimeout)
+            })
+        });
+
+        test(`close file`, async () => {
+            msgController.closeFile(-1);
+        }, connectTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/IMAGE_FITTING_FITS.test.ts
+++ b/src/test/IMAGE_FITTING_FITS.test.ts
@@ -17,6 +17,8 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     fittingRequest: CARTA.IFittingRequest[];
     fittingResponse: CARTA.IFittingResponse[];
+    iterationNumber1: string;
+    iterationNumber2: string;
     precisionDigits: number;
 };
 
@@ -106,6 +108,8 @@ let assertItem: AssertItem = {
         }
     ],
     precisionDigits: 2,
+    iterationNumber1: 'number of iterations = 68',
+    iterationNumber2: 'number of iterations = 116' 
 };
 
 let basepath: string;
@@ -159,6 +163,7 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                    expect(response.log).toContain(assertItem.iterationNumber1);
                 },imageFittingTimeout)
             })
 
@@ -180,6 +185,7 @@ describe("IMAGE_FITTING_FITS test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[1].log);
+                    expect(response.log).toContain(assertItem.iterationNumber2);
                 },imageFittingTimeout)
             })
         });

--- a/src/test/IMAGE_FITTING_HDF5.test.ts
+++ b/src/test/IMAGE_FITTING_HDF5.test.ts
@@ -17,6 +17,8 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     fittingRequest: CARTA.IFittingRequest[];
     fittingResponse: CARTA.IFittingResponse[];
+    iterationNumber1: string;
+    iterationNumber2: string;
     precisionDigits: number;
 };
 
@@ -106,6 +108,8 @@ let assertItem: AssertItem = {
         }
     ],
     precisionDigits: 2,
+    iterationNumber1: 'number of iterations = 68',
+    iterationNumber2: 'number of iterations = 116' 
 };
 
 let basepath: string;
@@ -159,6 +163,7 @@ describe("IMAGE_FITTING_HDF5 test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                    expect(response.log).toContain(assertItem.iterationNumber1);
                 },imageFittingTimeout)
             })
 
@@ -180,6 +185,7 @@ describe("IMAGE_FITTING_HDF5 test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[1].log);
+                    expect(response.log).toContain(assertItem.iterationNumber2);
                 },imageFittingTimeout)
             })
         });

--- a/src/test/IMAGE_FITTING_HDF5.test.ts
+++ b/src/test/IMAGE_FITTING_HDF5.test.ts
@@ -1,0 +1,193 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let imageFittingTimeout: number = config.timeout.imageFitting;
+
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    fittingRequest: CARTA.IFittingRequest[];
+    fittingResponse: CARTA.IFittingResponse[];
+    precisionDigits: number;
+};
+
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "M17_SWex-channel0-addOneGaussian.hdf5",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },    
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    fittingRequest: [
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: null,
+            regionId: -1, 
+            initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
+        },
+        {
+            fileId: 0,
+            fixedParams: [],
+            fovInfo: {
+                controlPoints: [{x:319.5, y:399.5}, {x: 216.70644391408112, y: 199.99999999999997}],
+                regionType: 3,
+                rotation: 0,
+            },
+            regionId: 0, 
+            initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
+        }
+    ],
+    fittingResponse: [
+        {
+            resultValues: [
+                {
+                    center: {x: 319.4995814506346, y: 399.4997816490029}, 
+                    amp: 9.999559472737332,
+                    fwhm: {x: 170.63727122575295, y: 41.48182201673784},
+                    pa: 142.16266600131718
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {x: 0.0004006969240219716, y: 0.0005001794973076322},
+                    amp: 0.00003971187313364324,
+                    fwhm: {x: 0.0008773295469374465, y: 0.00021417449809861666},
+                    pa: 0.00020655506565535857
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 1 component'
+        },
+        {
+            resultValues: [
+                {
+                    center: {x: 319.498940837943, y: 399.4988615251924}, 
+                    amp: 9.999454722592997,
+                    fwhm: {x: 170.6382683676851, y: 41.48206117869241},
+                    pa: 142.16251357416306
+                }
+            ],
+            resultErrors: [
+                {
+                    center: {x: 0.00010950493723812066, y: 0.0001246435132691238},
+                    amp: 0.000020566430029630594,
+                    fwhm: {x: 0.0004562033522657872, y: 0.00010502008093686605},
+                    pa: 0.00010562266856995906
+                }
+            ],
+            success: true,
+            log: 'Gaussian fitting with 1 component'
+        }
+    ],
+    precisionDigits: 2,
+};
+
+let basepath: string;
+describe("IMAGE_FITTING_HDF5 test: Testing Image Fitting (with and without fov) with hdf5 file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.filelist.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            describe(`(Step 0) Initialization: open the image`, () => {
+                test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                    msgController.closeFile(-1);
+                    msgController.closeFile(0);
+                    let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+    
+                test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                    msgController.addRequiredTiles(assertItem.addTilesReq);
+                    let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                }, openFileTimeout);
+            });
+
+            describe(`(Case 1) Image fitting without FoV:`, ()=>{
+                test(`Send Image fitting request and match the result`, async()=>{
+                    let response = await msgController.requestFitting(assertItem.fittingRequest[0]);
+                    
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[0].success);
+                    expect(response.resultErrors[0].center.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].center.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].amp).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
+                    expect(response.log).toContain(assertItem.fittingResponse[0].log);
+                },imageFittingTimeout)
+            })
+
+            describe(`(Case 2) Image fitting with FoV:`, ()=>{
+                test(`Send Image fitting request and match the result`, async()=>{
+                    let response = await msgController.requestFitting(assertItem.fittingRequest[1]);
+                    
+                    expect(response.resultValues[0].center.x).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].center.y).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].amp).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].amp, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultValues[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultValues[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultValues[0].pa, assertItem.precisionDigits);
+                    expect(response.success).toEqual(assertItem.fittingResponse[1].success);
+                    expect(response.resultErrors[0].center.x).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].center.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].center.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].center.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].amp).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].amp, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.x).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.x, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
+                    expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
+                    expect(response.log).toContain(assertItem.fittingResponse[1].log);
+                },imageFittingTimeout)
+            })
+        });
+
+        test(`close file`, async () => {
+            msgController.closeFile(-1);
+        }, connectTimeout);
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/IMAGE_FITTING_HDF5.test.ts
+++ b/src/test/IMAGE_FITTING_HDF5.test.ts
@@ -17,8 +17,6 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     fittingRequest: CARTA.IFittingRequest[];
     fittingResponse: CARTA.IFittingResponse[];
-    iterationNumber1: string;
-    iterationNumber2: string;
     precisionDigits: number;
 };
 
@@ -48,14 +46,14 @@ let assertItem: AssertItem = {
     fittingRequest: [
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: null,
             regionId: -1, 
             initialValues: [{amp: 10, center: {x: 320, y: 400}, fwhm: {x: 100, y: 50}, pa: 135}]
         },
         {
             fileId: 0,
-            fixedParams: [],
+            fixedParams: [false, false, false, false, false, false],
             fovInfo: {
                 controlPoints: [{x:319.5, y:399.5}, {x: 216.70644391408112, y: 199.99999999999997}],
                 regionType: 3,
@@ -108,8 +106,6 @@ let assertItem: AssertItem = {
         }
     ],
     precisionDigits: 2,
-    iterationNumber1: 'number of iterations = 68',
-    iterationNumber2: 'number of iterations = 116' 
 };
 
 let basepath: string;
@@ -163,7 +159,6 @@ describe("IMAGE_FITTING_HDF5 test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[0].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[0].log);
-                    expect(response.log).toContain(assertItem.iterationNumber1);
                 },imageFittingTimeout)
             })
 
@@ -185,7 +180,6 @@ describe("IMAGE_FITTING_HDF5 test: Testing Image Fitting (with and without fov) 
                     expect(response.resultErrors[0].fwhm.y).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].fwhm.y, assertItem.precisionDigits);
                     expect(response.resultErrors[0].pa).toBeCloseTo(assertItem.fittingResponse[1].resultErrors[0].pa, assertItem.precisionDigits);
                     expect(response.log).toContain(assertItem.fittingResponse[1].log);
-                    expect(response.log).toContain(assertItem.iterationNumber2);
                 },imageFittingTimeout)
             })
         });

--- a/src/test/MATCH_SPATIAL.test.ts
+++ b/src/test/MATCH_SPATIAL.test.ts
@@ -1,0 +1,284 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.moment;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let cursorTimeout = config.timeout.cursor;
+let profileTimeout = config.timeout.spatralProfile;
+
+interface IIndexValue {
+    index: number;
+    value: number;
+}
+interface ISingleProfile {
+    coordinate: string;
+    inrawValuesFp32: IIndexValue[];
+}
+interface AssertItem {
+    precisionDigits: number;
+    openFile: CARTA.IOpenFile[];
+    setCursor: CARTA.ISetCursor[];
+    spatialProfileData: CARTA.ISpatialProfileData[];
+    setSpatialRequirements: CARTA.ISetSpatialRequirements[];
+    profiles: CARTA.ISpatialProfile[];
+    testProfile: ISingleProfile[];
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    openFile: [
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.fits",
+            fileId: 100,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_13CO_2-1.fits",
+            fileId: 101,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_C18O_2-1.fits",
+            fileId: 102,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.image",
+            fileId: 103,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 100,
+            point: { x: 200.0, y: 200.0 },
+            spatialRequirements: {
+                fileId: 100,
+                regionId: 0,
+                spatialProfiles: [],
+            },
+        },
+        {
+            fileId: 101,
+            point: { x: 200.0, y: 200.0 },
+            spatialRequirements: {
+                fileId: 100,
+                regionId: 0,
+                spatialProfiles: [],
+            },
+        },
+        {
+            fileId: 102,
+            point: { x: 200.0, y: 200.0 },
+            spatialRequirements: {
+                fileId: 100,
+                regionId: 0,
+                spatialProfiles: [],
+            },
+        },
+        {
+            fileId: 103,
+            point: { x: 200.0, y: 200.0 },
+            spatialRequirements: {
+                fileId: 100,
+                regionId: 0,
+                spatialProfiles: [],
+            },
+        },
+    ],
+    spatialProfileData: [
+        {
+            profiles: [],
+            fileId: 100,
+            x: 200,
+            y: 200,
+            value: -0.0023265306372195482,
+        },
+        {
+            profiles: [],
+            fileId: 101,
+            x: 200,
+            y: 200,
+            value: -0.003293930785730481,
+        },
+        {
+            profiles: [],
+            fileId: 102,
+            x: 200,
+            y: 200,
+            value: 0.00045203242916613817,
+        },
+        {
+            profiles: [],
+            fileId: 103,
+            x: 200,
+            y: 200,
+            value: -0.0023265306372195482,
+        },
+    ],
+    setSpatialRequirements: [
+        {
+            fileId: 100,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x",mip:1}, {coordinate:"y",mip:1}],
+        },
+        {
+            fileId: 100,
+            regionId: 0,
+            spatialProfiles: [],
+        },
+        {
+            fileId: 103,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x",mip:1}, {coordinate:"y",mip:1}],
+        },
+    ],
+    profiles: [
+        {
+            coordinate: 'x', end: 432,
+        },
+        {
+            coordinate: 'y', end: 432,
+        },
+    ],
+    testProfile: [
+        {
+            coordinate: 'x',
+            inrawValuesFp32: [
+                {
+                    index: 0,
+                    value: 36,
+                },
+                {
+                    index: 500,
+                    value: 242,
+                },
+                {
+                    index: 1000,
+                    value: 86,
+                },
+                {
+                    index: 1500,
+                    value: 48,
+                },
+            ],
+        },
+        {
+            coordinate: 'y',
+            inrawValuesFp32: [
+                {
+                    index: 0,
+                    value: 84,
+                },
+                {
+                    index: 500,
+                    value: 163,
+                },
+                {
+                    index: 1000,
+                    value: 231,
+                },
+                {
+                    index: 1500,
+                    value: 66,
+                },
+            ],
+        },
+    ],
+};
+
+let basepath: string;
+describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            for (let index = 0; index < assertItem.openFile.length; index++) {
+                assertItem.openFile[index].directory = basepath + "/" + assertItem.openFile[index].directory;
+            }
+        });
+
+        describe(`Prepare images`, () => {
+            msgController.closeFile(-1);
+            for (const file of assertItem.openFile) {
+                test(`Should open image ${file.file} as file_id: ${file.fileId}`, async () => {
+                    let OpenFileResponse = await msgController.loadFile(file);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+            }
+        });
+
+        for (const [index, cursor] of assertItem.setCursor.entries()) {
+            describe(`Set cursor ${index}`, () => {
+                test(`Assert SpatialProfileData ${JSON.stringify(assertItem.spatialProfileData[index])}`, async () => {
+                    await msgController.setCursor(cursor.fileId, cursor.point.x, cursor.point.y);
+                    let spatialProfileData = await Stream(CARTA.SpatialProfileData,1);
+                    expect(spatialProfileData[0]).toMatchObject(assertItem.spatialProfileData[index]);
+                    expect(spatialProfileData[0].regionId).toEqual(0);
+                }, cursorTimeout);
+            });
+        }
+
+        let spatialProfileData0: CARTA.SpatialProfileData;
+        describe(`Set Spatial Requirements for file_id = ${assertItem.setSpatialRequirements[0].fileId}`, () => {
+            let spatialProfileData: CARTA.SpatialProfileData;
+            test(`Assert SpatialProfileData`, async () => {
+                await msgController.setSpatialRequirements(assertItem.setSpatialRequirements[0]);
+                spatialProfileData = await Stream(CARTA.SpatialProfileData,1);
+                spatialProfileData0 = spatialProfileData[0];
+                expect(spatialProfileData[0].profiles).toMatchObject(assertItem.profiles);
+                expect(spatialProfileData[0].regionId).toEqual(0);
+                let testingArrayX = spatialProfileData[0].profiles.find(profile => profile.coordinate == 'x').rawValuesFp32;
+                assertItem.testProfile[0].inrawValuesFp32.map(Coordinates => {
+                    expect(testingArrayX[Coordinates.index]).toEqual(Coordinates.value)
+                });
+                let testingArrayY = spatialProfileData[0].profiles.find(profile => profile.coordinate == 'y').rawValuesFp32;
+                assertItem.testProfile[1].inrawValuesFp32.map(Coordinates => {
+                    expect(testingArrayY[Coordinates.index]).toEqual(Coordinates.value)
+                });
+            }, profileTimeout);
+        });
+
+        describe(`Set Spatial Requirements for file_id = ${assertItem.setSpatialRequirements[2].fileId}`, () => {
+            let spatialProfileData: CARTA.SpatialProfileData[];
+            test(`Should receive SpatialProfileData x2`, async () => {
+                await msgController.setSpatialRequirements(assertItem.setSpatialRequirements[1]);
+                await msgController.setSpatialRequirements(assertItem.setSpatialRequirements[2]);
+                spatialProfileData = await Stream(CARTA.SpatialProfileData,2);
+            }, profileTimeout);
+    
+            test(`Assert SPATIAL_PROFILE_DATA[first, last].profiles.length = [0, 2]`, () => {
+                expect(spatialProfileData.find(data => data.fileId==assertItem.openFile[0].fileId).profiles.length).toEqual(0);
+                expect(spatialProfileData.find(data => data.fileId==assertItem.openFile[3].fileId).profiles.length).toEqual(2);
+            });
+    
+            test(`Assert SPATIAL_PROFILE_DATA of file_id:${assertItem.setSpatialRequirements[0].fileId} & file_id:${assertItem.setSpatialRequirements[2].fileId} are equal`, () => {
+                let spatialProfileData1 = spatialProfileData.find(data => data.fileId==assertItem.openFile[3].fileId);
+                delete spatialProfileData1.fileId;
+                const spatialProfileData2 = spatialProfileData0;
+                delete spatialProfileData2.fileId;
+                expect(spatialProfileData1).toStrictEqual(spatialProfileData2);
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/MATCH_SPECTRAL.test.ts
+++ b/src/test/MATCH_SPECTRAL.test.ts
@@ -236,7 +236,7 @@ describe("MATCH_SPECTRAL: Test region spectral profile with spatially and spectr
                     let SpectralProfileDataResponse = await Stream(CARTA.SpectralProfileData);
                     SpectralProfileData.push(SpectralProfileDataResponse[0]);                    
                 }
-            }, profileTimeout);
+            }, profileTimeout * 3);
     
             test(`Assert all region_id`, () => {
                 for (const [index, spectralRequirement] of assertItem.setSpectralRequirements.entries()) {

--- a/src/test/MATCH_SPECTRAL.test.ts
+++ b/src/test/MATCH_SPECTRAL.test.ts
@@ -1,0 +1,254 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.moment;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let regionTimeout = config.timeout.region;
+let cursorTimeout = config.timeout.cursor;
+let profileTimeout = config.timeout.spectralProfile;
+
+interface AssertItem {
+    precisionDigits: number;
+    openFile: CARTA.IOpenFile[];
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setSpectralRequirements: CARTA.ISetSpectralRequirements[];
+    setRegion: CARTA.ISetRegion[];
+}
+
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    openFile: [
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.fits",
+            fileId: 100,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_13CO_2-1.fits",
+            fileId: 101,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_C18O_2-1.fits",
+            fileId: 102,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.image",
+            fileId: 103,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    addTilesReq: [
+        {
+            fileId: 100,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 101,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 102,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 103,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 100,
+            point: { x: 200.0, y: 200.0 },
+        },
+        {
+            fileId: 101,
+            point: { x: 200.0, y: 200.0 },
+        },
+        {
+            fileId: 102,
+            point: { x: 200.0, y: 200.0 },
+        },
+        {
+            fileId: 103,
+            point: { x: 200.0, y: 200.0 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 100,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 101,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 102,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 103,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setSpectralRequirements: [
+        {
+            fileId: 100,
+            regionId: 1,
+            spectralProfiles: [{ coordinate: "z", statsTypes: [2] }],
+        },
+        {
+            fileId: 101,
+            regionId: 1,
+            spectralProfiles: [{ coordinate: "z", statsTypes: [2] }],
+        },
+        {
+            fileId: 102,
+            regionId: 1,
+            spectralProfiles: [{ coordinate: "z", statsTypes: [2] }],
+        },
+        {
+            fileId: 103,
+            regionId: 1,
+            spectralProfiles: [{ coordinate: "z", statsTypes: [2] }],
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 100,
+            regionId: 1,
+            regionInfo: {
+                regionType: 3,
+                rotation: 0,
+                controlPoints: [{ x: 200, y: 200 }, { x: 200, y: 200 }],
+            },
+        },
+        {
+            fileId: 100,
+            regionId: 1,
+            regionInfo: {
+                regionType: 3,
+                rotation: 30,
+                controlPoints: [{ x: 200, y: 200 }, { x: 200, y: 200 }],
+            },
+        },
+    ],
+};
+
+let basepath: string;
+describe("MATCH_SPECTRAL: Test region spectral profile with spatially and spectrally matched images", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            for (let index = 0; index < assertItem.openFile.length; index++) {
+                assertItem.openFile[index].directory = basepath + "/" + assertItem.openFile[index].directory;
+            }
+        });
+
+        describe(`Prepare images`, () => {
+            msgController.closeFile(-1);
+            for (const file of assertItem.openFile) {
+                test(`Should open image ${file.file} as file_id: ${file.fileId}`, async () => {
+                    let OpenFileResponse = await msgController.loadFile(file);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+            };
+            for (const [index, cursor] of assertItem.setCursor.entries()) {
+                test(`Prepare image ${index}`, async () => {
+                    msgController.addRequiredTiles(assertItem.addTilesReq[index]);
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[index].tiles.length + 2);
+
+                    msgController.setCursor(cursor.fileId, cursor.point.x, cursor.point.y);
+                    let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                    msgController.setSpatialRequirements(assertItem.setSpatialReq[index]);
+                    let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+                }, cursorTimeout);
+            };
+            test(`Should set region 1`, async () => {
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.success).toEqual(true);
+            }, regionTimeout);
+        });
+
+        describe(`Test acquire all spectral profiles`, () => {
+            let SpectralProfileData: CARTA.SpectralProfileData[] = [];
+            test(`Should receive 4 spectral_requirements`, async () => {
+                for (const [index, spectralRequirement] of assertItem.setSpectralRequirements.entries()) {
+                    await msgController.setSpectralRequirements(spectralRequirement);
+                    let SpectralProfileDataResponse = await Stream(CARTA.SpectralProfileData);
+                    SpectralProfileData.push(SpectralProfileDataResponse[0]);                    
+                }
+            }, profileTimeout);
+    
+            test(`Assert all region_id equal to ${assertItem.setSpectralRequirements[0].regionId}`, () => {
+                for (const [index, spectralRequirement] of assertItem.setSpectralRequirements.entries()) {
+                    expect(SpectralProfileData.find(data => data.fileId == spectralRequirement.fileId).regionId).toEqual(spectralRequirement.regionId);
+                }
+            });
+    
+            test(`Assert the first profile equal to the last profile`, () => {
+                expect(SpectralProfileData.find(data => data.fileId == assertItem.openFile[0].fileId).profiles).toEqual(SpectralProfileData.find(data => data.fileId == assertItem.openFile[3].fileId).profiles);
+            });
+        });
+
+        describe(`Test acquire all spectral profiles after enlarge region`, () => {
+            let SpectralProfileData: CARTA.SpectralProfileData[] = [];
+            test(`Should rotate region 1`, async () => {
+                await msgController.setRegion(assertItem.setRegion[1].fileId, assertItem.setRegion[1].regionId, assertItem.setRegion[1].regionInfo);
+                for (const [index, spectralRequirement] of assertItem.setSpectralRequirements.entries()) {
+                    let SpectralProfileDataResponse = await Stream(CARTA.SpectralProfileData);
+                    SpectralProfileData.push(SpectralProfileDataResponse[0]);                    
+                }
+            }, profileTimeout);
+    
+            test(`Assert all region_id`, () => {
+                for (const [index, spectralRequirement] of assertItem.setSpectralRequirements.entries()) {
+                    expect(SpectralProfileData.find(data => data.fileId == spectralRequirement.fileId).regionId).toEqual(spectralRequirement.regionId);
+                }
+            });
+    
+            test(`Assert the first profile equal to the last profile`, () => {
+                expect(SpectralProfileData.find(data => data.fileId == assertItem.openFile[0].fileId).profiles).toEqual(SpectralProfileData.find(data => data.fileId == assertItem.openFile[3].fileId).profiles);
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/MATCH_STATS.test.ts
+++ b/src/test/MATCH_STATS.test.ts
@@ -1,0 +1,310 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.moment;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let regionTimeout = config.timeout.region;
+let cursorTimeout = config.timeout.cursor;
+let profileTimeout = config.timeout.spectralProfile;
+
+interface AssertItem {
+    precisionDigits: number;
+    openFile: CARTA.IOpenFile[];
+    setCursor: CARTA.ISetCursor[];
+    setRegion: CARTA.ISetRegion[];
+    setStatsRequirements: CARTA.ISetStatsRequirements[][];
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    openFile: [
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.fits",
+            fileId: 100,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.image",
+            fileId: 101,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 100,
+            point: { x: 200.0, y: 200.0 },
+        },
+        {
+            fileId: 101,
+            point: { x: 200.0, y: 200.0 },
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 100,
+            regionId: 1,
+            regionInfo: {
+                regionType: 3,
+                rotation: 0,
+                controlPoints: [{ x: 250, y: 200 }, { x: 300, y: 300 }],
+            },
+        },
+        {
+            fileId: 100,
+            regionId: 2,
+            regionInfo: {
+                regionType: 3,
+                rotation: 25,
+                controlPoints: [{ x: 350, y: 350 }, { x: 100, y: 150 }],
+            },
+        },
+        {
+            fileId: 100,
+            regionId: 3,
+            regionInfo: {
+                regionType: 4,
+                rotation: 25,
+                controlPoints: [{ x: 150, y: 150 }, { x: 60, y: 100 }],
+            },
+        },
+        {
+            fileId: 100,
+            regionId: 4,
+            regionInfo: {
+                regionType: 6,
+                controlPoints: [{ x: 100, y: 150 }, { x: 400, y: 400 }, { x: 300, y: 30 }],
+            },
+        },
+    ],
+    setStatsRequirements: [
+        [
+            {
+                fileId: 100,
+                regionId: 1,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+            {
+                fileId: 100,
+                regionId: 2,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+            {
+                fileId: 100,
+                regionId: 3,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+            {
+                fileId: 100,
+                regionId: 4,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+        ],
+        [
+            {
+                fileId: 101,
+                regionId: 1,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+            {
+                fileId: 101,
+                regionId: 2,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+            {
+                fileId: 101,
+                regionId: 3,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+            {
+                fileId: 101,
+                regionId: 4,
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+            },
+        ],
+    ]
+};
+
+let basepath: string;
+describe("MATCH_STATS: Testing region stats with spatially and spectrally matched images", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            for (let index = 0; index < assertItem.openFile.length; index++) {
+                assertItem.openFile[index].directory = basepath + "/" + assertItem.openFile[index].directory;
+            }
+        });
+
+        describe(`Prepare images`, () => {
+            msgController.closeFile(-1);
+            for (const file of assertItem.openFile) {
+                test(`Should open image ${file.file} as file_id: ${file.fileId}`, async () => {
+                    let OpenFileResponse = await msgController.loadFile(file);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                }, openFileTimeout);
+            }
+
+            for (const [index, cursor] of assertItem.setCursor.entries()) {
+                test(`Should set cursor ${index}`, async () => {
+                    await msgController.setCursor(cursor.fileId, cursor.point.x, cursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                }, cursorTimeout);
+            }
+
+            for (const [index, region] of assertItem.setRegion.entries()) {
+                test(`Should set region ${region.regionId}`, async () => {
+                    let SetRegionAckResponse = await msgController.setRegion(region.fileId, region.regionId, region.regionInfo);
+                }, regionTimeout);
+            }
+        });
+
+        describe(`Test if the stats results are equal`, () => {
+            let RegionStatsData: CARTA.RegionStatsData[] = [];
+            for (const [fileIdx, file] of assertItem.openFile.entries()) {
+                test(`Should receive 4 RegionStatsData for file_id: ${file.fileId}`, async () => {
+                    for (const [statsIdx, statsReq] of assertItem.setStatsRequirements[fileIdx].entries()) {
+                        await msgController.setStatsRequirements({
+                            fileId: file.fileId,
+                            regionId: statsReq.regionId,
+                            stats: [],
+                        })
+                        await msgController.setStatsRequirements(statsReq);
+                        RegionStatsData.push(await Stream(CARTA.RegionStatsData,1));
+                    }
+                }, profileTimeout);
+
+                test(`Assert region_id for file_id: ${file.fileId}`, () => {
+                    for (const [regionIdx, region] of assertItem.setRegion.entries()) {
+                        expect(RegionStatsData.find(data => data[0].fileId == file.fileId && data[0].regionId == region.regionId)[0].statistics.length).toBeGreaterThan(0);
+                    }
+                });
+            }
+            for (const [regionIdx, region] of assertItem.setRegion.entries()) {
+                for (const [statsIdx, statsType] of assertItem.setStatsRequirements[0][regionIdx].statsConfigs[0].statsTypes.entries()) {
+                    test(`Assert the ${CARTA.StatsType[statsType]} of region ${region.regionId} for first image equal to that for the second image`, () => {
+                        const left = RegionStatsData.find(data => data[0].fileId == assertItem.openFile[0].fileId && data[0].regionId == region.regionId)[0].statistics.find(data => data.statsType == statsType).value;
+                        const right = RegionStatsData.find(data => data[0].fileId == assertItem.openFile[1].fileId && data[0].regionId == region.regionId)[0].statistics.find(data => data.statsType == statsType).value;
+                        if (isNaN(left) || isNaN(right)) {
+                            expect(Object.is(left, right)).toBe(true);
+                        } else {
+                            expect(left).toBeCloseTo(right, assertItem.precisionDigits);
+                        }
+                    });
+                }
+            }
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
@@ -81,7 +81,7 @@ describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an 
                         next: (data) => {
                             count++;
                             momentProgressArray.push(data);
-                            if (data.progress > 0.5 && count == 5) {
+                            if (count == 5) {
                                 msgController.cancelRequestingMoment(setFileId);
                                 resolve(momentProgressArray)
                             }

--- a/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
@@ -1,0 +1,156 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController, ConnectionStatus } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let momentTimeout = config.timeout.moment;
+const setFileId = 200;
+interface AssertItem {
+    precisionDigit: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    momentRequest: CARTA.IMomentRequest;
+};
+
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        hdu: "",
+        fileId: setFileId,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    momentRequest: {
+        fileId: setFileId,
+        regionId: 0,
+        axis: CARTA.MomentAxis.SPECTRAL,
+        mask: CARTA.MomentMask.Include,
+        moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        pixelRange: { min: 0.1, max: 1.0 },
+        spectralRange: { min: 73, max: 114 },
+    },
+};
+
+let basepath: string;
+describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an image", () => {
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readFileTimeout);
+        });
+
+        describe(`Moment generator cancel`, () => {
+            let momentProgressArray = [];
+            let momentProgressReponse : any;
+            let momentResponse : any;
+            let count = 0;
+            test(`Request a moment progress but cancel after receiving 5 MomentProgress`, async () => {
+                await sleep(200);
+                let momentProgressPromise = new Promise((resolve)=>{
+                    msgController.momentProgressStream.subscribe({
+                        next: (data) => {
+                            count++;
+                            momentProgressArray.push(data);
+                            if (data.progress > 0.5 && count == 5) {
+                                msgController.cancelRequestingMoment(setFileId);
+                                resolve(momentProgressArray)
+                            }
+                        }
+                    })
+                })
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest);
+                momentProgressReponse = await momentProgressPromise;
+            }, momentTimeout)
+
+            test(`Assert MomentProgress.progress < 1.0`, () => {
+                momentProgressReponse.map(ack => {
+                    expect(ack.progress).toBeLessThan(1.0);
+                });
+            });
+
+            test(`Receive no MomentProgress till 500 ms`, done => {
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter);
+                    let checkConnectionStatus = msgController.checkConnectionStatus();
+                    expect(checkConnectionStatus).toEqual(ConnectionStatus.ACTIVE);
+                    done();
+                }, 500)
+            });
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+    
+            test(`Assert MomentResponse.cancel = true`, () => {
+                expect(momentResponse.cancel).toBe(true);
+            });
+    
+            test(`Assert openFileAcks[] is empty`, () => {
+                expect(momentResponse.openFileAcks.length).toBe(0);
+            });
+        });
+
+        describe(`Moment generator`, () => {
+            let momentResponse : any;
+            test(`Receive a series of moment progress`, async () => {
+                await sleep(5000);
+                momentResponse = await msgController.requestMoment({
+                    ...assertItem.momentRequest,
+                    moments: [12],
+                });
+            }, momentTimeout); 
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+
+            test(`Assert openFileAcks[].fileInfo.name = "HD163296_CO_2_1.fits.moment.minimum_coord"`, () => {
+                expect(momentResponse.openFileAcks[0].fileInfo.name).toEqual("HD163296_CO_2_1.fits.moment.minimum_coord");
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.fileInfoExtended.height).toEqual(432);
+                    expect(ack.fileInfoExtended.width).toEqual(432);
+                    expect(ack.fileInfoExtended.dimensions).toEqual(4);
+                    expect(ack.fileInfoExtended.depth).toEqual(1);
+                    expect(ack.fileInfoExtended.stokes).toEqual(1);
+                });
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
@@ -75,7 +75,6 @@ describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an 
             let momentResponse : any;
             let count = 0;
             test(`Request a moment progress but cancel after receiving 5 MomentProgress`, async () => {
-                await sleep(200);
                 let momentProgressPromise = new Promise((resolve)=>{
                     msgController.momentProgressStream.subscribe({
                         next: (data) => {
@@ -125,7 +124,6 @@ describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an 
         describe(`Moment generator`, () => {
             let momentResponse : any;
             test(`Receive a series of moment progress`, async () => {
-                await sleep(5000);
                 momentResponse = await msgController.requestMoment({
                     ...assertItem.momentRequest,
                     moments: [12],

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -1,0 +1,258 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let regionTimeout = config.timeout.region;
+let momentTimeout = config.timeout.moment;
+const setFileId = 200;
+interface AssertItem {
+    precisionDigit: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    setRegion: CARTA.ISetRegion;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements;
+    momentRequest: CARTA.IMomentRequest;
+    imageDataLength: number[];
+    nanEncodingsLength: number[];
+};
+
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.image",
+        hdu: "",
+        fileId: setFileId,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setRegion: {
+        fileId: setFileId,
+        regionId: -1,
+        regionInfo: {
+            regionType: CARTA.RegionType.RECTANGLE,
+            controlPoints: [{ x: 218, y: 218.0 }, { x: 200.0, y: 200.0 }],
+            rotation: 0,
+        },
+    },
+    setSpectralRequirements: {
+        fileId: setFileId,
+        regionId: 1,
+        spectralProfiles: [{ coordinate: "z", statsTypes: [CARTA.StatsType.Sum] }],
+    },
+    momentRequest: {
+        fileId: setFileId,
+        regionId: 1,
+        axis: CARTA.MomentAxis.SPECTRAL,
+        mask: CARTA.MomentMask.Include,
+        moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        pixelRange: { min: 0.1, max: 1.0 },
+        spectralRange: { min: 73, max: 114 },
+    },
+    imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
+    nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
+};
+const momentName = [
+    "average", "integrated", "weighted_coord", "weighted_dispersion_coord",
+    "median", "median_coord", "standard_deviation", "rms", "abs_mean_dev",
+    "maximum", "maximum_coord", "minimum", "minimum_coord",
+];
+const imageData5000 = [ // Testing the compressed imageData[5000] of each moment image
+109, 213, 248, 83,
+124, 15, 0, 99, 31,
+97, 0, 175, 26,
+];
+
+const imageData10000 = [ // Testing the compressed imageData[10000] of each moment image
+124, 177, 5, 42,
+229, 1, 121, 15, 8,
+228, 21, 92, 199,
+];
+
+const imageData20000 = [ // Testing the compressed imageData[20000] of each moment image
+174, 31, 4, 12,
+151, 82, 226, 141, 131,
+101, 60, 103, 0,
+];
+
+const imageData30000 = [ // Testing the compressed imageData[30000] of each moment image
+23, 44, 145, 127,
+180, 64, 63, 51, 202,
+67, 160, 25, 227,
+];
+
+let basepath: string;
+describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region on a casa image", () => {
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readFileTimeout);
+    
+            test(`Set region`, async () => {
+                let SetRegionAck = await msgController.setRegion(assertItem.setRegion.fileId, assertItem.setRegion.regionId, assertItem.setRegion.regionInfo)
+                msgController.setSpectralRequirements(assertItem.setSpectralRequirements);
+                let spectralProfileDataResponse = await Stream(CARTA.SpectralProfileData, 1);
+            }, regionTimeout);
+        });
+
+        let FileId: number[] = [];
+        let regionHistogramDataArray = [];
+        let momentResponse: any;
+        let regionHistogramDataResponse: any;
+        describe(`Moment generator`, () => {
+            test(`Receive a series of moment progress`, async () => {
+                await sleep(200);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramDataArray.push(data)
+                            resolve(regionHistogramDataArray)
+                        }
+                    })
+                });
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest);
+                regionHistogramDataResponse = await regionHistogramDataPromise;
+                FileId = regionHistogramDataResponse.map(data => data.fileId);
+            }, momentTimeout);
+
+            test(`Receive ${assertItem.momentRequest.moments.length} REGION_HISTOGRAM_DATA`, () => {
+                expect(regionHistogramDataResponse.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+
+            test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest.moments.length}`, () => {
+                expect(momentResponse.openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.success).toBe(true);
+                });
+            });
+
+            test(`Assert all openFileAcks[].fileId > 0`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.fileId).toBeGreaterThan(0);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfo.name`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfo.name).toEqual(assertItem.openFile.file + ".moment." + momentName[index]);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    const coord = assertItem.setRegion.regionInfo.controlPoints;
+                    expect(ack.fileInfoExtended.height).toEqual(coord[1].y + 1);
+                    expect(ack.fileInfoExtended.width).toEqual(coord[1].x + 1);
+                    expect(ack.fileInfoExtended.dimensions).toEqual(4);
+                    expect(ack.fileInfoExtended.depth).toEqual(1);
+                    expect(ack.fileInfoExtended.stokes).toEqual(1);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 85`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfoExtended.headerEntries.length).toEqual(85);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 21`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfoExtended.computedEntries.length).toEqual(21);
+                });
+            });
+        });
+
+        describe(`Requset moment image`, () => {
+            let RasterTileSync: CARTA.RasterTileSync[] = [];
+            let RasterTileData: CARTA.RasterTileData[] = [];
+            test(`Receive all image data until RasterTileSync.endSync = true`, async () => {
+                for (let idx = 0; idx < FileId.length; idx++) {
+                    msgController.addRequiredTiles({
+                        fileId: FileId[idx],
+                        tiles: [0],
+                        compressionType: CARTA.CompressionType.ZFP,
+                        compressionQuality: 0,
+                    })
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+                    RasterTileSync.push(RasterTileDataResponse[2]);
+                    RasterTileData.push(RasterTileDataResponse[1]);
+                }
+                RasterTileSync.map(ack => {
+                    expect(ack.endSync).toBe(true);
+                });
+            }, readFileTimeout * FileId.length);
+
+            test(`Assert RASTER_TILE_SYNC.fileId`, () => {
+                RasterTileSync.map((ack, index) => {
+                    expect(ack.fileId).toEqual(FileId[index]);
+                });
+            });
+
+            test(`Receive RASTER_TILE_DATA`, () => {
+                expect(RasterTileData.length).toEqual(FileId.length);
+            });
+    
+            test(`Assert RASTER_TILE_DATA.fileId`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.fileId).toEqual(FileId[index]);
+                });
+            });
+
+            test(`Assert RASTER_TILE_DATA.tiles`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.tiles[0].height).toEqual(201);
+                    expect(ack.tiles[0].width).toEqual(201);
+                    expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
+                    expect(ack.tiles[0].nanEncodings.length).toEqual(assertItem.nanEncodingsLength[index]);
+                });
+            });
+    
+            test(`Assert RASTER_TILE_DATA.tiles[0].imageData[5000], imageData[10000], imageData[20000], and imageData[30000]`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.tiles[0].imageData[5000]).toEqual(imageData5000[index]);
+                    expect(ack.tiles[0].imageData[10000]).toEqual(imageData10000[index]);
+                    expect(ack.tiles[0].imageData[20000]).toEqual(imageData20000[index]);
+                    expect(ack.tiles[0].imageData[30000]).toEqual(imageData30000[index]);
+                });
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
+++ b/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
@@ -1,0 +1,182 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController, ConnectionStatus } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let momentTimeout = config.timeout.moment;
+
+interface AssertItem {
+    precisionDigit: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    momentRequest: CARTA.IMomentRequest[];
+    setCursor: CARTA.ISetCursor;
+};
+
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    momentRequest: [
+        {
+            fileId: 0,
+            regionId: 0,
+            axis: CARTA.MomentAxis.SPECTRAL,
+            mask: CARTA.MomentMask.Include,
+            moments: [0, 1, 2,],
+            pixelRange: { min: 0.1, max: 1.0 },
+            spectralRange: { min: 73, max: 114 },
+        },
+        {
+            fileId: 0,
+            regionId: 0,
+            axis: CARTA.MomentAxis.SPECTRAL,
+            mask: CARTA.MomentMask.Include,
+            moments: [0, 1,],
+            pixelRange: { min: 0.1, max: 1.0 },
+            spectralRange: { min: 73, max: 114 },
+        },
+    ],
+    setCursor: {
+        point: { x: 218, y: 218 },
+    },
+};
+
+let basepath: string;
+describe("MOMENTS_GENERATOR_EXCEPTION: Testing moments generator for exception", () => {
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readFileTimeout);
+
+            let regionHistogramDataArray = [];
+            let momentResponse: any;
+            test(`Request 3 moment images`, async () => {
+                await sleep(200);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramDataArray.push(data)
+                            resolve(regionHistogramDataArray)
+                        }
+                    })
+                });
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest[0]);
+            });
+        });
+
+        let FileId: number[] = [];
+        describe(`Moment generator again`, () => {
+            let regionHistogramDataArray = [];
+            let regionHistogramDataResponse: any;
+            let momentResponse: any;
+            let momentProgressArray = [];
+            let momentProgressReponse: any;
+            test(`Receive a series of moment progress & MomentProgress.progress < 1`, async () => {
+                await sleep(200);
+                let momentProgressPromise = new Promise((resolve)=>{
+                    msgController.momentProgressStream.subscribe({
+                        next: (data) => {
+                            momentProgressArray.push(data);
+                            resolve(momentProgressArray)
+                        }
+                    })
+                })
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramDataArray.push(data)
+                            resolve(regionHistogramDataArray)
+                        }
+                    })
+                });
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest[1]);
+                regionHistogramDataResponse = await regionHistogramDataPromise;
+                momentProgressReponse = await momentProgressPromise;
+                FileId = regionHistogramDataResponse.map(data => data.fileId);
+                expect(momentProgressReponse.length).toBeGreaterThan(0);
+            }, momentTimeout);
+
+            test(`Receive ${assertItem.momentRequest[1].moments.length} REGION_HISTOGRAM_DATA`, () => {
+                expect(FileId.length).toEqual(assertItem.momentRequest[1].moments.length);
+            });
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+    
+            test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest[1].moments.length}`, () => {
+                expect(momentResponse.openFileAcks.length).toEqual(assertItem.momentRequest[1].moments.length);
+            });
+    
+            test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.success).toBe(true);
+                });
+            });
+        });
+
+        describe(`Requset moment image`, () => {
+            let SpatialProfileData: any;
+            test(`Receive the image data until RasterTileSync.endSync = true`, async () => {
+                msgController.addRequiredTiles({
+                    fileId: FileId[1] + 1,
+                    tiles: [0],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 11,
+                })
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+            });
+
+            test(`Receive SpatialProfileData`, async () => {
+                msgController.setCursor(FileId[1] + 1, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                SpatialProfileData = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`Assert SpatialProfileData[0].value`, () => {
+                expect(SpatialProfileData[0].value).toBeCloseTo(7.8840599, assertItem.precisionDigit);
+            });
+
+            test(`Assert backend is still alive`, () => {
+                let checkConnectionStatus = msgController.checkConnectionStatus();
+                expect(checkConnectionStatus).toEqual(ConnectionStatus.ACTIVE);
+            })
+
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -121,7 +121,7 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
                 let SetRegionAck = await msgController.setRegion(assertItem.setRegion.fileId, assertItem.setRegion.regionId, assertItem.setRegion.regionInfo)
                 msgController.setSpectralRequirements(assertItem.setSpectralRequirements);
                 let spectralProfileDataResponse = await Stream(CARTA.SpectralProfileData, 1);
-            }, regionTimeout);
+            }, regionTimeout * 10);
         });
 
         let FileId: number[] = [];

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -1,0 +1,258 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let regionTimeout = config.timeout.region;
+let momentTimeout = config.timeout.moment;
+const setFileId = 200;
+interface AssertItem {
+    precisionDigit: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    setRegion: CARTA.ISetRegion;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements;
+    momentRequest: CARTA.IMomentRequest;
+    imageDataLength: number[];
+    nanEncodingsLength: number[];
+};
+
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        hdu: "",
+        fileId: setFileId,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setRegion: {
+        fileId: setFileId,
+        regionId: -1,
+        regionInfo: {
+            regionType: CARTA.RegionType.RECTANGLE,
+            controlPoints: [{ x: 218, y: 218.0 }, { x: 200.0, y: 200.0 }],
+            rotation: 0,
+        },
+    },
+    setSpectralRequirements: {
+        fileId: setFileId,
+        regionId: 1,
+        spectralProfiles: [{ coordinate: "z", statsTypes: [CARTA.StatsType.Sum] }],
+    },
+    momentRequest: {
+        fileId: setFileId,
+        regionId: 1,
+        axis: CARTA.MomentAxis.SPECTRAL,
+        mask: CARTA.MomentMask.Include,
+        moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        pixelRange: { min: 0.1, max: 1.0 },
+        spectralRange: { min: 73, max: 114 },
+    },
+    imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
+    nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
+};
+const momentName = [
+    "average", "integrated", "weighted_coord", "weighted_dispersion_coord",
+    "median", "median_coord", "standard_deviation", "rms", "abs_mean_dev",
+    "maximum", "maximum_coord", "minimum", "minimum_coord",
+];
+const imageData5000 = [ // Testing the compressed imageData[5000] of each moment image
+109, 213, 248, 83,
+124, 15, 0, 99, 31,
+97, 0, 175, 26,
+];
+
+const imageData10000 = [ // Testing the compressed imageData[10000] of each moment image
+124, 177, 5, 42,
+229, 1, 121, 15, 8,
+228, 21, 92, 199,
+];
+
+const imageData20000 = [ // Testing the compressed imageData[20000] of each moment image
+174, 31, 4, 12,
+151, 82, 226, 141, 131,
+101, 60, 103, 0,
+];
+
+const imageData30000 = [ // Testing the compressed imageData[30000] of each moment image
+23, 44, 145, 127,
+180, 64, 63, 51, 202,
+67, 160, 25, 227,
+];
+
+let basepath: string;
+describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region on a fits image", () => {
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readFileTimeout);
+    
+            test(`Set region`, async () => {
+                let SetRegionAck = await msgController.setRegion(assertItem.setRegion.fileId, assertItem.setRegion.regionId, assertItem.setRegion.regionInfo)
+                msgController.setSpectralRequirements(assertItem.setSpectralRequirements);
+                let spectralProfileDataResponse = await Stream(CARTA.SpectralProfileData, 1);
+            }, regionTimeout);
+        });
+
+        let FileId: number[] = [];
+        let regionHistogramDataArray = [];
+        let momentResponse: any;
+        let regionHistogramDataResponse: any;
+        describe(`Moment generator`, () => {
+            test(`Receive a series of moment progress`, async () => {
+                await sleep(200);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramDataArray.push(data)
+                            resolve(regionHistogramDataArray)
+                        }
+                    })
+                });
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest);
+                regionHistogramDataResponse = await regionHistogramDataPromise;
+                FileId = regionHistogramDataResponse.map(data => data.fileId);
+            }, momentTimeout);
+
+            test(`Receive ${assertItem.momentRequest.moments.length} REGION_HISTOGRAM_DATA`, () => {
+                expect(regionHistogramDataResponse.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+
+            test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest.moments.length}`, () => {
+                expect(momentResponse.openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.success).toBe(true);
+                });
+            });
+
+            test(`Assert all openFileAcks[].fileId > 0`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.fileId).toBeGreaterThan(0);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfo.name`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfo.name).toEqual(assertItem.openFile.file + ".moment." + momentName[index]);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    const coord = assertItem.setRegion.regionInfo.controlPoints;
+                    expect(ack.fileInfoExtended.height).toEqual(coord[1].y + 1);
+                    expect(ack.fileInfoExtended.width).toEqual(coord[1].x + 1);
+                    expect(ack.fileInfoExtended.dimensions).toEqual(4);
+                    expect(ack.fileInfoExtended.depth).toEqual(1);
+                    expect(ack.fileInfoExtended.stokes).toEqual(1);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 85`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfoExtended.headerEntries.length).toEqual(85);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 21`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfoExtended.computedEntries.length).toEqual(21);
+                });
+            });
+        });
+
+        describe(`Requset moment image`, () => {
+            let RasterTileSync: CARTA.RasterTileSync[] = [];
+            let RasterTileData: CARTA.RasterTileData[] = [];
+            test(`Receive all image data until RasterTileSync.endSync = true`, async () => {
+                for (let idx = 0; idx < FileId.length; idx++) {
+                    msgController.addRequiredTiles({
+                        fileId: FileId[idx],
+                        tiles: [0],
+                        compressionType: CARTA.CompressionType.ZFP,
+                        compressionQuality: 0,
+                    })
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+                    RasterTileSync.push(RasterTileDataResponse[2]);
+                    RasterTileData.push(RasterTileDataResponse[1]);
+                }
+                RasterTileSync.map(ack => {
+                    expect(ack.endSync).toBe(true);
+                });
+            }, readFileTimeout * FileId.length);
+
+            test(`Assert RASTER_TILE_SYNC.fileId`, () => {
+                RasterTileSync.map((ack, index) => {
+                    expect(ack.fileId).toEqual(FileId[index]);
+                });
+            });
+
+            test(`Receive RASTER_TILE_DATA`, () => {
+                expect(RasterTileData.length).toEqual(FileId.length);
+            });
+    
+            test(`Assert RASTER_TILE_DATA.fileId`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.fileId).toEqual(FileId[index]);
+                });
+            });
+
+            test(`Assert RASTER_TILE_DATA.tiles`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.tiles[0].height).toEqual(201);
+                    expect(ack.tiles[0].width).toEqual(201);
+                    expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
+                    expect(ack.tiles[0].nanEncodings.length).toEqual(assertItem.nanEncodingsLength[index]);
+                });
+            });
+    
+            test(`Assert RASTER_TILE_DATA.tiles[0].imageData[5000], imageData[10000], imageData[20000], and imageData[30000]`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.tiles[0].imageData[5000]).toEqual(imageData5000[index]);
+                    expect(ack.tiles[0].imageData[10000]).toEqual(imageData10000[index]);
+                    expect(ack.tiles[0].imageData[20000]).toEqual(imageData20000[index]);
+                    expect(ack.tiles[0].imageData[30000]).toEqual(imageData30000[index]);
+                });
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -1,0 +1,258 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let regionTimeout = config.timeout.region;
+let momentTimeout = config.timeout.moment;
+const setFileId = 200;
+interface AssertItem {
+    precisionDigit: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    setRegion: CARTA.ISetRegion;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements;
+    momentRequest: CARTA.IMomentRequest;
+    imageDataLength: number[];
+    nanEncodingsLength: number[];
+};
+
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.hdf5",
+        hdu: "",
+        fileId: setFileId,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setRegion: {
+        fileId: setFileId,
+        regionId: -1,
+        regionInfo: {
+            regionType: CARTA.RegionType.RECTANGLE,
+            controlPoints: [{ x: 218, y: 218.0 }, { x: 200.0, y: 200.0 }],
+            rotation: 0,
+        },
+    },
+    setSpectralRequirements: {
+        fileId: setFileId,
+        regionId: 1,
+        spectralProfiles: [{ coordinate: "z", statsTypes: [CARTA.StatsType.Sum] }],
+    },
+    momentRequest: {
+        fileId: setFileId,
+        regionId: 1,
+        axis: CARTA.MomentAxis.SPECTRAL,
+        mask: CARTA.MomentMask.Include,
+        moments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        pixelRange: { min: 0.1, max: 1.0 },
+        spectralRange: { min: 73, max: 114 },
+    },
+    imageDataLength: [72560, 72480, 59320, 67560, 74128, 32720, 68424, 72080, 70576, 67496, 32752, 76904, 61848],
+    nanEncodingsLength: [1424, 1424, 1424, 1424, 1424, 1424, 1448, 1424, 1424, 1424, 1424, 1424, 1424],
+};
+const momentName = [
+    "average", "integrated", "weighted_coord", "weighted_dispersion_coord",
+    "median", "median_coord", "standard_deviation", "rms", "abs_mean_dev",
+    "maximum", "maximum_coord", "minimum", "minimum_coord",
+];
+const imageData5000 = [ // Testing the compressed imageData[5000] of each moment image
+109, 213, 248, 83,
+124, 15, 0, 99, 31,
+97, 0, 175, 26,
+];
+
+const imageData10000 = [ // Testing the compressed imageData[10000] of each moment image
+124, 177, 5, 42,
+229, 1, 121, 15, 8,
+228, 21, 92, 199,
+];
+
+const imageData20000 = [ // Testing the compressed imageData[20000] of each moment image
+174, 31, 4, 12,
+151, 82, 226, 141, 131,
+101, 60, 103, 0,
+];
+
+const imageData30000 = [ // Testing the compressed imageData[30000] of each moment image
+23, 44, 145, 127,
+180, 64, 63, 51, 202,
+67, 160, 25, 227,
+];
+
+let basepath: string;
+describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region on a hdf5 image", () => {
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readFileTimeout);
+    
+            test(`Set region`, async () => {
+                let SetRegionAck = await msgController.setRegion(assertItem.setRegion.fileId, assertItem.setRegion.regionId, assertItem.setRegion.regionInfo)
+                msgController.setSpectralRequirements(assertItem.setSpectralRequirements);
+                let spectralProfileDataResponse = await Stream(CARTA.SpectralProfileData, 1);
+            }, regionTimeout);
+        });
+
+        let FileId: number[] = [];
+        let regionHistogramDataArray = [];
+        let momentResponse: any;
+        let regionHistogramDataResponse: any;
+        describe(`Moment generator`, () => {
+            test(`Receive a series of moment progress`, async () => {
+                await sleep(200);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramDataArray.push(data)
+                            resolve(regionHistogramDataArray)
+                        }
+                    })
+                });
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest);
+                regionHistogramDataResponse = await regionHistogramDataPromise;
+                FileId = regionHistogramDataResponse.map(data => data.fileId);
+            }, momentTimeout);
+
+            test(`Receive ${assertItem.momentRequest.moments.length} REGION_HISTOGRAM_DATA`, () => {
+                expect(regionHistogramDataResponse.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+
+            test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest.moments.length}`, () => {
+                expect(momentResponse.openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.success).toBe(true);
+                });
+            });
+
+            test(`Assert all openFileAcks[].fileId > 0`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.fileId).toBeGreaterThan(0);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfo.name`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfo.name).toEqual(assertItem.openFile.file + ".moment." + momentName[index]);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    const coord = assertItem.setRegion.regionInfo.controlPoints;
+                    expect(ack.fileInfoExtended.height).toEqual(coord[1].y + 1);
+                    expect(ack.fileInfoExtended.width).toEqual(coord[1].x + 1);
+                    expect(ack.fileInfoExtended.dimensions).toEqual(4);
+                    expect(ack.fileInfoExtended.depth).toEqual(1);
+                    expect(ack.fileInfoExtended.stokes).toEqual(1);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 90`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfoExtended.headerEntries.length).toEqual(90);
+                });
+            });
+
+            test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 21`, () => {
+                momentResponse.openFileAcks.map((ack, index) => {
+                    expect(ack.fileInfoExtended.computedEntries.length).toEqual(21);
+                });
+            });
+        });
+
+        describe(`Requset moment image`, () => {
+            let RasterTileSync: CARTA.RasterTileSync[] = [];
+            let RasterTileData: CARTA.RasterTileData[] = [];
+            test(`Receive all image data until RasterTileSync.endSync = true`, async () => {
+                for (let idx = 0; idx < FileId.length; idx++) {
+                    msgController.addRequiredTiles({
+                        fileId: FileId[idx],
+                        tiles: [0],
+                        compressionType: CARTA.CompressionType.ZFP,
+                        compressionQuality: 0,
+                    })
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData, 3);
+                    RasterTileSync.push(RasterTileDataResponse[2]);
+                    RasterTileData.push(RasterTileDataResponse[1]);
+                }
+                RasterTileSync.map(ack => {
+                    expect(ack.endSync).toBe(true);
+                });
+            }, readFileTimeout * FileId.length);
+
+            test(`Assert RASTER_TILE_SYNC.fileId`, () => {
+                RasterTileSync.map((ack, index) => {
+                    expect(ack.fileId).toEqual(FileId[index]);
+                });
+            });
+
+            test(`Receive RASTER_TILE_DATA`, () => {
+                expect(RasterTileData.length).toEqual(FileId.length);
+            });
+    
+            test(`Assert RASTER_TILE_DATA.fileId`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.fileId).toEqual(FileId[index]);
+                });
+            });
+
+            test(`Assert RASTER_TILE_DATA.tiles`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.tiles[0].height).toEqual(201);
+                    expect(ack.tiles[0].width).toEqual(201);
+                    expect(ack.tiles[0].imageData.length).toEqual(assertItem.imageDataLength[index]);
+                    expect(ack.tiles[0].nanEncodings.length).toEqual(assertItem.nanEncodingsLength[index]);
+                });
+            });
+    
+            test(`Assert RASTER_TILE_DATA.tiles[0].imageData[5000], imageData[10000], imageData[20000], and imageData[30000]`, () => {
+                RasterTileData.map((ack, index) => {
+                    expect(ack.tiles[0].imageData[5000]).toEqual(imageData5000[index]);
+                    expect(ack.tiles[0].imageData[10000]).toEqual(imageData10000[index]);
+                    expect(ack.tiles[0].imageData[20000]).toEqual(imageData20000[index]);
+                    expect(ack.tiles[0].imageData[30000]).toEqual(imageData30000[index]);
+                });
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -1,0 +1,162 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let saveSubdirectory = config.path.save;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let saveFileTimeout = config.timeout.saveFile;
+let momentTimeout = config.timeout.moment;
+
+interface AssertItem {
+    precisionDigit: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    momentRequest: CARTA.IMomentRequest;
+    saveFile: CARTA.ISaveFile[][];
+};
+
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    momentRequest: {
+        fileId: 0,
+        regionId: 0,
+        axis: CARTA.MomentAxis.SPECTRAL,
+        mask: CARTA.MomentMask.Include,
+        moments: [0, 1,],
+        pixelRange: { min: 0.1, max: 1.0 },
+        spectralRange: { min: 73, max: 114 },
+    },
+    saveFile: [
+        [
+            {
+                outputFileDirectory: saveSubdirectory,
+                outputFileName: 'HD163296_CO_2_1.fits.moment.average.fits',
+                outputFileType: CARTA.FileType.FITS,
+            },
+            {
+                outputFileDirectory: saveSubdirectory,
+                outputFileName: 'HD163296_CO_2_1.fits.moment.integrated.fits',
+                outputFileType: CARTA.FileType.FITS,
+            },
+        ],
+        [
+            {
+                outputFileDirectory: saveSubdirectory,
+                outputFileName: 'HD163296_CO_2_1.fits.moment.average.image',
+                outputFileType: CARTA.FileType.CASA,
+            },
+            {
+                outputFileDirectory: saveSubdirectory,
+                outputFileName: 'HD163296_CO_2_1.fits.moment.integrated.image',
+                outputFileType: CARTA.FileType.CASA,
+            },
+        ],
+    ],
+};
+
+let basepath: string;
+describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region on a fits image", () => {
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readFileTimeout);
+        });
+
+        let FileId: number[] = [];
+        let regionHistogramDataArray = [];
+        let momentResponse: any;
+        let regionHistogramDataResponse: any;
+        describe(`Moment generator`, () => {
+            test(`Receive a series of moment progress`, async () => {
+                await sleep(200);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramDataArray.push(data)
+                            resolve(regionHistogramDataArray)
+                        }
+                    })
+                });
+                momentResponse = await msgController.requestMoment(assertItem.momentRequest);
+                regionHistogramDataResponse = await regionHistogramDataPromise;
+                FileId = regionHistogramDataResponse.map(data => data.fileId);
+            }, momentTimeout);
+
+            test(`Receive ${assertItem.momentRequest.moments.length} REGION_HISTOGRAM_DATA`, () => {
+                expect(regionHistogramDataResponse.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert MomentResponse.success = true`, () => {
+                expect(momentResponse.success).toBe(true);
+            });
+
+            test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest.moments.length}`, () => {
+                expect(momentResponse.openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
+            });
+
+            test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
+                momentResponse.openFileAcks.map(ack => {
+                    expect(ack.success).toBe(true);
+                });
+            });
+        });
+
+        describe(`Save images`, () => {
+            let saveFileAck: any[] = [];
+            for (let i = 0; i < assertItem.saveFile.length; i++) {
+                for (let j = 0; j < assertItem.saveFile[i].length; j++) {
+                    test(`Save moment generated image ${assertItem.saveFile[i][j].outputFileName}`, async () => {
+                        let saveFileResponse = await msgController.saveFile(FileId[j], assertItem.saveFile[i][j].outputFileDirectory, assertItem.saveFile[i][j].outputFileName, assertItem.saveFile[i][j].outputFileType);
+                        saveFileAck.push(saveFileResponse);
+                        await sleep(200);
+                        expect(saveFileAck.slice(-1)[0].fileId).toEqual(FileId[j]);
+                    }, saveFileTimeout);
+                }
+            }
+    
+            test(`Assert all message.success = true`, () => {
+                saveFileAck.map((ack, index) => {
+                    expect(ack.success).toBe(true);
+                });
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/MessageController-concurrent.ts
+++ b/src/test/MessageController-concurrent.ts
@@ -1,0 +1,960 @@
+import {action, makeObservable, observable, runInAction} from "mobx";
+import {CARTA} from "carta-protobuf";
+import {Subject, throwError} from "rxjs";
+const WebSocket = require("ws");
+
+export enum ConnectionStatus {
+    CLOSED = 0,
+    PENDING = 1,
+    ACTIVE = 2
+}
+
+export const INVALID_ANIMATION_ID = -1;
+
+type HandlerFunction = (eventId: number, parsedMessage: any) => void;
+
+interface IBackendResponse {
+    success?: boolean;
+    message?: string;
+}
+
+// Deferred class adapted from https://stackoverflow.com/a/58610922/1727322
+export class Deferred<T> {
+    private _resolve: (value: T) => void = () => {};
+    private _reject: (reason: any) => void = () => {};
+
+    private _promise: Promise<T> = new Promise<T>((resolve, reject) => {
+        this._reject = reject;
+        this._resolve = resolve;
+    });
+
+    public get promise(): Promise<T> {
+        return this._promise;
+    }
+
+    public resolve(value: T) {
+        this._resolve(value);
+    }
+
+    public reject(reason: any) {
+        this._reject(reason);
+    }
+}
+
+export class BackendService {
+    public static staticInstance: BackendService;
+
+    static get Instance() {
+        if (!BackendService.staticInstance) {
+            BackendService.staticInstance = new BackendService();
+        }
+        return BackendService.staticInstance;
+    }
+
+    private static readonly IcdVersion = 28;
+    private static readonly DefaultFeatureFlags = CARTA.ClientFeatureFlags.WEB_ASSEMBLY | CARTA.ClientFeatureFlags.WEB_GL;
+    private static readonly MaxConnectionAttempts = 15;
+    private static readonly ConnectionAttemptDelay = 1000;
+
+    @observable connectionStatus: ConnectionStatus;
+    readonly loggingEnabled: boolean;
+    @observable connectionDropped: boolean;
+    @observable endToEndPing: number;
+
+    public animationId: number;
+    public sessionId: number;
+    public serverFeatureFlags: number;
+    public serverUrl: string;
+
+    private connection: WebSocket;
+    private lastPingTime: number;
+    private lastPongTime: number;
+    private deferredMap: Map<number, Deferred<IBackendResponse>>;
+    private eventCounter: number;
+
+    readonly rasterTileStream: Subject<CARTA.RasterTileData>;
+    readonly rasterSyncStream: Subject<CARTA.RasterTileSync>;
+    readonly histogramStream: Subject<CARTA.RegionHistogramData>;
+    readonly errorStream: Subject<CARTA.ErrorData>;
+    readonly spatialProfileStream: Subject<CARTA.SpatialProfileData>;
+    readonly spectralProfileStream: Subject<CARTA.SpectralProfileData>;
+    readonly statsStream: Subject<CARTA.RegionStatsData>;
+    readonly contourStream: Subject<CARTA.ContourImageData>;
+    readonly catalogStream: Subject<CARTA.CatalogFilterResponse>;
+    readonly momentProgressStream: Subject<CARTA.MomentProgress>;
+    readonly scriptingStream: Subject<CARTA.ScriptingRequest>;
+    readonly listProgressStream: Subject<CARTA.ListProgress>;
+    readonly pvProgressStream: Subject<CARTA.PvProgress>;
+    readonly vectorTileStream: Subject<CARTA.VectorOverlayTileData>;
+    private readonly decoderMap: Map<CARTA.EventType, {messageClass: any; handler: HandlerFunction}>;
+
+    public constructor() {
+        makeObservable(this);
+        this.loggingEnabled = true;
+        this.deferredMap = new Map<number, Deferred<IBackendResponse>>();
+
+        this.eventCounter = 1;
+        this.sessionId = 0;
+        this.endToEndPing = NaN;
+        this.animationId = INVALID_ANIMATION_ID;
+        this.connectionStatus = ConnectionStatus.CLOSED;
+        this.rasterTileStream = new Subject<CARTA.RasterTileData>();
+        this.rasterSyncStream = new Subject<CARTA.RasterTileSync>();
+        this.histogramStream = new Subject<CARTA.RegionHistogramData>();
+        this.errorStream = new Subject<CARTA.ErrorData>();
+        this.spatialProfileStream = new Subject<CARTA.SpatialProfileData>();
+        this.spectralProfileStream = new Subject<CARTA.SpectralProfileData>();
+        this.statsStream = new Subject<CARTA.RegionStatsData>();
+        this.contourStream = new Subject<CARTA.ContourImageData>();
+        this.scriptingStream = new Subject<CARTA.ScriptingRequest>();
+        this.catalogStream = new Subject<CARTA.CatalogFilterResponse>();
+        this.momentProgressStream = new Subject<CARTA.MomentProgress>();
+        this.listProgressStream = new Subject<CARTA.ListProgress>();
+        this.pvProgressStream = new Subject<CARTA.PvProgress>();
+        this.vectorTileStream = new Subject<CARTA.VectorOverlayTileData>();
+
+        // Construct handler and decoder maps
+        this.decoderMap = new Map<CARTA.EventType, {messageClass: any; handler: HandlerFunction}>([
+            [CARTA.EventType.REGISTER_VIEWER_ACK, {messageClass: CARTA.RegisterViewerAck, handler: this.onRegisterViewerAck}],
+            [CARTA.EventType.FILE_LIST_RESPONSE, {messageClass: CARTA.FileListResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.REGION_LIST_RESPONSE, {messageClass: CARTA.RegionListResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.CATALOG_LIST_RESPONSE, {messageClass: CARTA.CatalogListResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.FILE_LIST_PROGRESS, {messageClass: CARTA.ListProgress, handler: this.onStreamedListProgress}],
+            // [CARTA.EventType.FILE_INFO_RESPONSE, {messageClass: CARTA.FileInfoResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.REGION_FILE_INFO_RESPONSE, {messageClass: CARTA.RegionFileInfoResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.CATALOG_FILE_INFO_RESPONSE, {messageClass: CARTA.CatalogFileInfoResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.OPEN_FILE_ACK, {messageClass: CARTA.OpenFileAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.SAVE_FILE_ACK, {messageClass: CARTA.SaveFileAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.OPEN_CATALOG_FILE_ACK, {messageClass: CARTA.OpenCatalogFileAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.IMPORT_REGION_ACK, {messageClass: CARTA.ImportRegionAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.EXPORT_REGION_ACK, {messageClass: CARTA.ExportRegionAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.SET_REGION_ACK, {messageClass: CARTA.SetRegionAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.RESUME_SESSION_ACK, {messageClass: CARTA.ResumeSessionAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.START_ANIMATION_ACK, {messageClass: CARTA.StartAnimationAck, handler: this.onStartAnimationAck}],
+            // [CARTA.EventType.RASTER_TILE_DATA, {messageClass: CARTA.RasterTileData, handler: this.onStreamedRasterTileData}],
+            // [CARTA.EventType.REGION_HISTOGRAM_DATA, {messageClass: CARTA.RegionHistogramData, handler: this.onStreamedRegionHistogramData}],
+            // [CARTA.EventType.ERROR_DATA, {messageClass: CARTA.ErrorData, handler: this.onStreamedErrorData}],
+            // [CARTA.EventType.SPATIAL_PROFILE_DATA, {messageClass: CARTA.SpatialProfileData, handler: this.onStreamedSpatialProfileData}],
+            // [CARTA.EventType.SPECTRAL_PROFILE_DATA, {messageClass: CARTA.SpectralProfileData, handler: this.onStreamedSpectralProfileData}],
+            // [CARTA.EventType.REGION_STATS_DATA, {messageClass: CARTA.RegionStatsData, handler: this.onStreamedRegionStatsData}],
+            // [CARTA.EventType.CONTOUR_IMAGE_DATA, {messageClass: CARTA.ContourImageData, handler: this.onStreamedContourData}],
+            // [CARTA.EventType.CATALOG_FILTER_RESPONSE, {messageClass: CARTA.CatalogFilterResponse, handler: this.onStreamedCatalogData}],
+            // [CARTA.EventType.RASTER_TILE_SYNC, {messageClass: CARTA.RasterTileSync, handler: this.onStreamedRasterSync}],
+            // [CARTA.EventType.MOMENT_PROGRESS, {messageClass: CARTA.MomentProgress, handler: this.onStreamedMomentProgress}],
+            // [CARTA.EventType.MOMENT_RESPONSE, {messageClass: CARTA.MomentResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.SCRIPTING_REQUEST, {messageClass: CARTA.ScriptingRequest, handler: this.onScriptingRequest}],
+            // [CARTA.EventType.CONCAT_STOKES_FILES_ACK, {messageClass: CARTA.ConcatStokesFilesAck, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.PV_PROGRESS, {messageClass: CARTA.PvProgress, handler: this.onStreamedPvProgress}],
+            // [CARTA.EventType.PV_RESPONSE, {messageClass: CARTA.PvResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.FITTING_RESPONSE, {messageClass: CARTA.FittingResponse, handler: this.onDeferredResponse}],
+            // [CARTA.EventType.VECTOR_OVERLAY_TILE_DATA, {messageClass: CARTA.VectorOverlayTileData, handler: this.onStreamedVectorOverlayData}]
+        ]);
+
+        // check ping every 5 seconds
+        // setInterval(this.sendPing, 5000);
+    }
+
+    @action("connect")
+    async connect(url: string): Promise<CARTA.IRegisterViewerAck> {
+        if (this.connection) {
+            this.connection.onclose = null;
+            this.connection.close();
+        }
+
+        const isReconnection: boolean = url === this.serverUrl;
+        let connectionAttempts = 0;
+        // const apiService = ApiService.Instance;
+        this.connectionDropped = false;
+        this.connectionStatus = ConnectionStatus.PENDING;
+        this.serverUrl = url;
+        this.connection = new WebSocket(url);
+        this.connection.binaryType = "arraybuffer";
+        this.connection.onmessage = this.messageHandler.bind(this);
+        this.connection.onclose = (ev: CloseEvent) =>
+            runInAction(() => {
+                // Only change to closed connection if the connection was originally active or this is a reconnection
+                if (this.connectionStatus === ConnectionStatus.ACTIVE || isReconnection || connectionAttempts >= BackendService.MaxConnectionAttempts) {
+                    this.connectionStatus = ConnectionStatus.CLOSED;
+                } else {
+                    connectionAttempts++;
+                    setTimeout(() => {
+                        const newConnection = new WebSocket(url);
+                        newConnection.binaryType = "arraybuffer";
+                        newConnection.onopen = this.connection.onopen;
+                        newConnection.onerror = this.connection.onerror;
+                        newConnection.onclose = this.connection.onclose;
+                        newConnection.onmessage = this.connection.onmessage;
+                        this.connection = newConnection;
+                    }, BackendService.ConnectionAttemptDelay);
+                }
+            });
+
+        this.deferredMap.clear();
+        this.eventCounter = 1;
+        const requestId = this.eventCounter;
+
+        const deferredResponse = new Deferred<CARTA.IRegisterViewerAck>();
+        this.deferredMap.set(requestId, deferredResponse);
+
+        this.connection.onopen = action(() => {
+            if (this.connectionStatus === ConnectionStatus.CLOSED) {
+                this.connectionDropped = true;
+            }
+            this.connectionStatus = ConnectionStatus.ACTIVE;
+            const message = CARTA.RegisterViewer.create({sessionId: this.sessionId, clientFeatureFlags: BackendService.DefaultFeatureFlags});
+            // observer map is cleared, so that old subscriptions don't get incorrectly fired
+
+            this.logEvent(CARTA.EventType.REGISTER_VIEWER, requestId, message, false);
+            if (this.sendEvent(CARTA.EventType.REGISTER_VIEWER, CARTA.RegisterViewer.encode(message).finish())) {
+                this.deferredMap.set(requestId, deferredResponse);
+            } else {
+                throw new Error("Could not send event");
+            }
+        });
+
+        this.connection.onerror = ev => {
+            // AppStore.Instance.logStore.addInfo(`Connecting to server ${url} failed.`, ["network"]);
+            console.log(ev);
+        };
+
+        return await deferredResponse.promise;
+    }
+
+
+    @action closeConnection = () => {
+        if (this.connection && this.connectionStatus !== ConnectionStatus.CLOSED) {
+            this.connection.close();
+        }
+    }
+
+    async getFileList(directory: string, filterMode: CARTA.FileListFilterMode): Promise<CARTA.IFileListResponse> {
+        if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+            throw new Error("Not connected");
+        } else {
+            const message = CARTA.FileListRequest.create({directory, filterMode});
+            const requestId = this.eventCounter;
+            this.logEvent(CARTA.EventType.FILE_LIST_REQUEST, requestId, message, false);
+            if (this.sendEvent(CARTA.EventType.FILE_LIST_REQUEST, CARTA.FileListRequest.encode(message).finish())) {
+                const deferredResponse = new Deferred<CARTA.IFileListResponse>();
+                this.deferredMap.set(requestId, deferredResponse);
+                return await deferredResponse.promise;
+            } else {
+                throw new Error("Could not send event");
+            }
+        }
+    }
+
+    // async getRegionList(directory: string, filterMode: CARTA.FileListFilterMode): Promise<CARTA.IRegionListResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.RegionListRequest.create({directory, filterMode});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.REGION_LIST_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.REGION_LIST_REQUEST, CARTA.RegionListRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IRegionListResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async getCatalogList(directory: string, filterMode: CARTA.FileListFilterMode): Promise<CARTA.ICatalogListResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.CatalogListRequest.create({directory, filterMode});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.CATALOG_LIST_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.CATALOG_LIST_REQUEST, CARTA.CatalogListRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.ICatalogListResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async getFileInfo(directory: string, file: string, hdu: string): Promise<CARTA.IFileInfoResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.FileInfoRequest.create({directory, file, hdu});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.FILE_INFO_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.FILE_INFO_REQUEST, CARTA.FileInfoRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IFileInfoResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async getRegionFileInfo(directory: string, file: string): Promise<CARTA.IRegionFileInfoResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.RegionFileInfoRequest.create({directory, file});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.REGION_FILE_INFO_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.REGION_FILE_INFO_REQUEST, CARTA.RegionFileInfoRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IRegionFileInfoResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async getCatalogFileInfo(directory: string, name: string): Promise<CARTA.ICatalogFileInfoResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.CatalogFileInfoRequest.create({directory, name});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.CATALOG_FILE_INFO_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.CATALOG_FILE_INFO_REQUEST, CARTA.CatalogFileInfoRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.ICatalogFileInfoResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async importRegion(directory: string, file: string, type: CARTA.FileType, fileId: number): Promise<CARTA.IImportRegionAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.ImportRegion.create({directory, file, type, groupId: fileId});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.IMPORT_REGION, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.IMPORT_REGION, CARTA.ImportRegion.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IImportRegionAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async exportRegion(directory: string, file: string, type: CARTA.FileType, coordType: CARTA.CoordinateType, fileId: number, regionStyles: Map<number, CARTA.IRegionStyle>): Promise<CARTA.IExportRegionAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(regionStyles), coordType});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.EXPORT_REGION, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.EXPORT_REGION, CARTA.ExportRegion.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IExportRegionAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async loadFile(directory: string, file: string, hdu: string, fileId: number, imageArithmetic: boolean): Promise<CARTA.IOpenFileAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.OpenFile.create({
+    //             directory,
+    //             file,
+    //             hdu,
+    //             fileId,
+    //             lelExpr: imageArithmetic,
+    //             renderMode: CARTA.RenderMode.RASTER
+    //         });
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.OPEN_FILE, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.OPEN_FILE, CARTA.OpenFile.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IOpenFileAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async loadStokeFiles(stokesFiles: CARTA.IStokesFile[], fileId: number, renderMode: CARTA.RenderMode): Promise<CARTA.IConcatStokesFilesAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const concatStokes: CARTA.IConcatStokesFiles = {
+    //             stokesFiles: stokesFiles,
+    //             fileId: fileId,
+    //             renderMode: renderMode
+    //         };
+    //         const message = CARTA.ConcatStokesFiles.create(concatStokes);
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.CONCAT_STOKES_FILES, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.CONCAT_STOKES_FILES, CARTA.ConcatStokesFiles.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IConcatStokesFilesAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // async loadCatalogFile(directory: string, name: string, fileId: number, previewDataSize: number): Promise<CARTA.IOpenCatalogFileAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.OpenCatalogFile.create({directory, name, fileId, previewDataSize});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.OPEN_CATALOG_FILE, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.OPEN_CATALOG_FILE, CARTA.OpenCatalogFile.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IOpenCatalogFileAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // @action("close catalog file")
+    // closeCatalogFile(fileId: number): boolean {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.CloseCatalogFile.create({fileId});
+    //         this.logEvent(CARTA.EventType.CLOSE_CATALOG_FILE, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.CLOSE_CATALOG_FILE, CARTA.CloseCatalogFile.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // async saveFile(
+    //     fileId: number,
+    //     outputFileDirectory: string,
+    //     outputFileName: string,
+    //     outputFileType: CARTA.FileType,
+    //     regionId?: number,
+    //     channels?: number[],
+    //     stokes?: number[],
+    //     keepDegenerate?: boolean,
+    //     restFreq?: number
+    // ): Promise<CARTA.ISaveFileAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.SaveFile.create({fileId, outputFileDirectory, outputFileName, outputFileType, regionId, channels, stokes, keepDegenerate, restFreq});
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.SAVE_FILE, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SAVE_FILE, CARTA.SaveFile.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.ISaveFileAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // closeFile(fileId: number): boolean {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.CloseFile.create({fileId});
+    //         this.logEvent(CARTA.EventType.CLOSE_FILE, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.CLOSE_FILE, CARTA.CloseFile.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set channels")
+    // setChannels(fileId: number, channel: number, stokes: number, requiredTiles: CARTA.IAddRequiredTiles): boolean {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.SetImageChannels.create({fileId, channel, stokes, requiredTiles});
+    //         this.logEvent(CARTA.EventType.SET_IMAGE_CHANNELS, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_IMAGE_CHANNELS, CARTA.SetImageChannels.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set cursor")
+    // setCursor(fileId: number, x: number, y: number): boolean {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.SetCursor.create({fileId, point: {x, y}});
+    //         this.logEvent(CARTA.EventType.SET_CURSOR, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_CURSOR, CARTA.SetCursor.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // async setRegion(fileId: number, regionId: number, region: RegionStore): Promise<CARTA.ISetRegionAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const message = CARTA.SetRegion.create({
+    //             fileId,
+    //             regionId,
+    //             regionInfo: {
+    //                 regionType: region.regionType,
+    //                 rotation: region.rotation,
+    //                 controlPoints: region.controlPoints.slice()
+    //             }
+    //         });
+
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.SET_REGION, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_REGION, CARTA.SetRegion.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.ISetRegionAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // @action("remove region")
+    // removeRegion(regionId: number) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.RemoveRegion.create({regionId});
+    //         this.logEvent(CARTA.EventType.REMOVE_REGION, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.REMOVE_REGION, CARTA.RemoveRegion.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set catalog filter")
+    // setCatalogFilterRequest(filterRequest: CARTA.ICatalogFilterRequest) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.CATALOG_FILTER_REQUEST, this.eventCounter, filterRequest, false);
+    //         if (this.sendEvent(CARTA.EventType.CATALOG_FILTER_REQUEST, CARTA.CatalogFilterRequest.encode(filterRequest).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set spatial requirements")
+    // setSpatialRequirements(requirementsMessage: CARTA.ISetSpatialRequirements) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SET_SPATIAL_REQUIREMENTS, this.eventCounter, requirementsMessage, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_SPATIAL_REQUIREMENTS, CARTA.SetSpatialRequirements.encode(requirementsMessage).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set spectral requirements")
+    // setSpectralRequirements(requirementsMessage: CARTA.ISetSpectralRequirements) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SET_SPECTRAL_REQUIREMENTS, this.eventCounter, requirementsMessage, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_SPECTRAL_REQUIREMENTS, CARTA.SetSpectralRequirements.encode(requirementsMessage).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set stats requirements")
+    // setStatsRequirements(requirementsMessage: CARTA.ISetStatsRequirements) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SET_STATS_REQUIREMENTS, this.eventCounter, requirementsMessage, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_STATS_REQUIREMENTS, CARTA.SetStatsRequirements.encode(requirementsMessage).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set histogram requirements")
+    // setHistogramRequirements(requirementsMessage: CARTA.ISetHistogramRequirements) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SET_HISTOGRAM_REQUIREMENTS, this.eventCounter, requirementsMessage, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_HISTOGRAM_REQUIREMENTS, CARTA.SetHistogramRequirements.encode(requirementsMessage).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("add required tiles")
+    // addRequiredTiles(fileId: number, tiles: Array<number>, quality: number): boolean {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.AddRequiredTiles.create({fileId, tiles, compressionQuality: quality, compressionType: CARTA.CompressionType.ZFP});
+    //         this.logEvent(CARTA.EventType.ADD_REQUIRED_TILES, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.ADD_REQUIRED_TILES, CARTA.AddRequiredTiles.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("remove required tiles")
+    // removeRequiredTiles(fileId: number, tiles: Array<number>): boolean {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         const message = CARTA.RemoveRequiredTiles.create({fileId, tiles});
+    //         this.logEvent(CARTA.EventType.REMOVE_REQUIRED_TILES, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.REMOVE_REQUIRED_TILES, CARTA.RemoveRequiredTiles.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // async startAnimation(animationMessage: CARTA.IStartAnimation): Promise<CARTA.IStartAnimationAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.START_ANIMATION, requestId, animationMessage, false);
+    //         if (this.sendEvent(CARTA.EventType.START_ANIMATION, CARTA.StartAnimation.encode(animationMessage).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IStartAnimationAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // @action("stop animation")
+    // stopAnimation(animationMessage: CARTA.IStopAnimation) {
+    //     this.animationId = INVALID_ANIMATION_ID;
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.STOP_ANIMATION, this.eventCounter, animationMessage, false);
+    //         if (this.sendEvent(CARTA.EventType.STOP_ANIMATION, CARTA.StopAnimation.encode(animationMessage).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("animation flow control")
+    // sendAnimationFlowControl(message: CARTA.IAnimationFlowControl) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.ANIMATION_FLOW_CONTROL, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.ANIMATION_FLOW_CONTROL, CARTA.AnimationFlowControl.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set contour parameters")
+    // setContourParameters(message: CARTA.ISetContourParameters) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SET_CONTOUR_PARAMETERS, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_CONTOUR_PARAMETERS, CARTA.SetContourParameters.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // @action("set vector overlay parameters")
+    // setVectorOverlayParameters(message: CARTA.ISetVectorOverlayParameters) {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SET_VECTOR_OVERLAY_PARAMETERS, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SET_VECTOR_OVERLAY_PARAMETERS, CARTA.SetVectorOverlayParameters.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
+
+    // async resumeSession(message: CARTA.IResumeSession): Promise<CARTA.IResumeSessionAck> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.RESUME_SESSION, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.RESUME_SESSION, CARTA.ResumeSession.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IResumeSessionAck>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // @action("set auth token")
+    // setAuthToken = (token: string) => {
+    //     document.cookie = `CARTA-Authorization=${token}; path=/`;
+    // };
+
+    // async requestMoment(message: CARTA.IMomentRequest): Promise<CARTA.IMomentResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.MOMENT_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.MOMENT_REQUEST, CARTA.MomentRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IMomentResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // cancelRequestingMoment(fileId: number) {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         return throwError(new Error("Not connected"));
+    //     } else {
+    //         const message = CARTA.StopMomentCalc.create({fileId});
+    //         this.logEvent(CARTA.EventType.STOP_MOMENT_CALC, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.STOP_MOMENT_CALC, CARTA.StopMomentCalc.encode(message).finish())) {
+    //             return true;
+    //         }
+    //         return throwError(new Error("Could not send event"));
+    //     }
+    // }
+
+    // @action("cancel requesting file list")
+    // cancelRequestingFileList(fileListType: CARTA.FileListType) {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         return throwError(new Error("Not connected"));
+    //     } else {
+    //         const message = CARTA.StopFileList.create({fileListType: fileListType});
+    //         this.logEvent(CARTA.EventType.STOP_FILE_LIST, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.STOP_FILE_LIST, new Uint8Array())) {
+    //             return true;
+    //         }
+    //         return throwError(new Error("Could not send event"));
+    //     }
+    // }
+
+    // async requestPV(message: CARTA.IPvRequest): Promise<CARTA.IPvResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.PV_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.PV_REQUEST, CARTA.PvRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IPvResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // cancelRequestingPV(fileId: number) {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         return throwError(new Error("Not connected"));
+    //     } else {
+    //         const message = CARTA.StopPvCalc.create({fileId});
+    //         this.logEvent(CARTA.EventType.STOP_PV_CALC, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.STOP_PV_CALC, CARTA.StopPvCalc.encode(message).finish())) {
+    //             return true;
+    //         }
+    //         return throwError(new Error("Could not send event"));
+    //     }
+    // }
+
+    // async requestFitting(message: CARTA.IFittingRequest): Promise<CARTA.IFittingResponse> {
+    //     if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
+    //         throw new Error("Not connected");
+    //     } else {
+    //         const requestId = this.eventCounter;
+    //         this.logEvent(CARTA.EventType.FITTING_REQUEST, requestId, message, false);
+    //         if (this.sendEvent(CARTA.EventType.FITTING_REQUEST, CARTA.FittingRequest.encode(message).finish())) {
+    //             const deferredResponse = new Deferred<CARTA.IFittingResponse>();
+    //             this.deferredMap.set(requestId, deferredResponse);
+    //             return await deferredResponse.promise;
+    //         } else {
+    //             throw new Error("Could not send event");
+    //         }
+    //     }
+    // }
+
+    // @action("send scripting response")
+    // sendScriptingResponse = (message: CARTA.IScriptingResponse) => {
+    //     if (this.connectionStatus === ConnectionStatus.ACTIVE) {
+    //         this.logEvent(CARTA.EventType.SCRIPTING_RESPONSE, this.eventCounter, message, false);
+    //         if (this.sendEvent(CARTA.EventType.SCRIPTING_RESPONSE, CARTA.ScriptingResponse.encode(message).finish())) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // };
+
+    // public serverHasFeature(feature: CARTA.ServerFeatureFlags): boolean {
+    //     return (this.serverFeatureFlags & feature) !== 0;
+    // }
+
+    private messageHandler(event: MessageEvent) {
+        if (event.data === "PONG") {
+            this.lastPongTime = performance.now();
+            // this.updateEndToEndPing();
+            return;
+        } else if (event.data.byteLength < 8) {
+            console.log("Unknown event format");
+            return;
+        }
+
+        const eventHeader16 = new Uint16Array(event.data, 0, 2);
+        const eventHeader32 = new Uint32Array(event.data, 4, 1);
+        const eventData = new Uint8Array(event.data, 8);
+
+        const eventType: CARTA.EventType = eventHeader16[0];
+        const eventIcdVersion = eventHeader16[1];
+        const eventId = eventHeader32[0];
+
+        if (eventIcdVersion !== BackendService.IcdVersion) {
+            console.warn(`Server event has ICD version ${eventIcdVersion}, which differs from frontend version ${BackendService.IcdVersion}. Errors may occur`);
+        }
+        try {
+            const decoderEntry = this.decoderMap.get(eventType);
+            if (decoderEntry) {
+                const parsedMessage = decoderEntry.messageClass.decode(eventData);
+                if (parsedMessage) {
+                    this.logEvent(eventType, eventId, parsedMessage);
+                    decoderEntry.handler.call(this, eventId, parsedMessage);
+                } else {
+                    console.log(`Unsupported event response ${eventType}`);
+                }
+            }
+        } catch (e) {
+            console.log(e);
+        }
+    }
+
+    private onDeferredResponse(eventId: number, response: IBackendResponse) {
+        const def = this.deferredMap.get(eventId);
+        if (def) {
+            if (response.success) {
+                def.resolve(response);
+            } else {
+                def.reject(response.message);
+            }
+        } else {
+            console.log(`Can't find deferred for request ${eventId}`);
+        }
+    }
+
+    private onRegisterViewerAck(eventId: number, ack: CARTA.RegisterViewerAck) {
+        this.sessionId = ack.sessionId;
+        this.serverFeatureFlags = ack.serverFeatureFlags;
+
+        // TelemetryService.Instance.addTelemetryEntry(TelemetryAction.Connection, {serverFeatureFlags: ack.serverFeatureFlags, platformInfo: ack.platformStrings});
+        this.onDeferredResponse(eventId, ack);
+    }
+
+    // private onStartAnimationAck(eventId: number, ack: CARTA.StartAnimationAck) {
+    //     this.animationId = ack.success ? ack.animationId : INVALID_ANIMATION_ID;
+    //     this.onDeferredResponse(eventId, ack);
+    // }
+
+    // private onStreamedRasterTileData(_eventId: number, rasterTileData: CARTA.RasterTileData) {
+    //     this.rasterTileStream.next(rasterTileData);
+    // }
+
+    // private onStreamedRasterSync(_eventId: number, rasterTileSync: CARTA.RasterTileSync) {
+    //     this.rasterSyncStream.next(rasterTileSync);
+    // }
+
+    // private onStreamedRegionHistogramData(_eventId: number, regionHistogramData: CARTA.RegionHistogramData) {
+    //     this.histogramStream.next(regionHistogramData);
+    // }
+
+    // private onStreamedErrorData(_eventId: number, errorData: CARTA.ErrorData) {
+    //     this.errorStream.next(errorData);
+    // }
+
+    // private onStreamedSpatialProfileData(_eventId: number, spatialProfileData: CARTA.SpatialProfileData) {
+    //     this.spatialProfileStream.next(spatialProfileData);
+    // }
+
+    // private onStreamedSpectralProfileData(_eventId: number, spectralProfileData: CARTA.SpectralProfileData) {
+    //     this.spectralProfileStream.next(spectralProfileData);
+    // }
+
+    // private onStreamedRegionStatsData(_eventId: number, regionStatsData: CARTA.RegionStatsData) {
+    //     this.statsStream.next(regionStatsData);
+    // }
+
+    // private onStreamedContourData(_eventId: number, contourData: CARTA.ContourImageData) {
+    //     this.contourStream.next(contourData);
+    // }
+
+    // private onStreamedVectorOverlayData(_eventId: number, overlayData: CARTA.VectorOverlayTileData) {
+    //     this.vectorTileStream.next(overlayData);
+    // }
+
+    // private onScriptingRequest(_eventId: number, scriptingRequest: CARTA.ScriptingRequest) {
+    //     this.scriptingStream.next(scriptingRequest);
+    // }
+
+    // private onStreamedCatalogData(_eventId: number, catalogFilter: CARTA.CatalogFilterResponse) {
+    //     this.catalogStream.next(catalogFilter);
+    // }
+
+    // private onStreamedMomentProgress(_eventId: number, momentProgress: CARTA.MomentProgress) {
+    //     this.momentProgressStream.next(momentProgress);
+    // }
+
+    // private onStreamedListProgress(_eventId: number, listProgress: CARTA.ListProgress) {
+    //     this.listProgressStream.next(listProgress);
+    // }
+
+    // private onStreamedPvProgress(_eventId: number, pvProgress: CARTA.PvProgress) {
+    //     this.pvProgressStream.next(pvProgress);
+    // }
+
+    private sendEvent(eventType: CARTA.EventType, payload: Uint8Array): boolean {
+        if (this.connection.readyState === WebSocket.OPEN) {
+            const eventData = new Uint8Array(8 + payload.byteLength);
+            const eventHeader16 = new Uint16Array(eventData.buffer, 0, 2);
+            const eventHeader32 = new Uint32Array(eventData.buffer, 4, 1);
+            eventHeader16[0] = eventType;
+            eventHeader16[1] = BackendService.IcdVersion;
+            eventHeader32[0] = this.eventCounter;
+
+            eventData.set(payload, 8);
+            this.connection.send(eventData);
+            this.eventCounter++;
+            return true;
+        } else {
+            console.log("Error sending event");
+            this.eventCounter++;
+            return false;
+        }
+    }
+
+    private logEvent(eventType: CARTA.EventType, eventId: number, message: any, incoming: boolean = true) {
+        const eventName = CARTA.EventType[eventType];
+        if (this.loggingEnabled) {
+            if (incoming) {
+                if (eventId === 0) {
+                    // console.log(`<== ${eventName} [Stream]`);
+                } else {
+                    // console.log(`<== ${eventName} [${eventId}]`);
+                }
+            } else {
+                // console.log(`${eventName} [${eventId}] ==>`);
+            }
+            // console.log(message);
+            // console.log("\n");
+        }
+    }
+}

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -228,12 +228,9 @@ export class MessageController {
         }
     }
 
-    // sendPing = () => {
-    //     if (this.connection && this.connectionStatus === ConnectionStatus.ACTIVE) {
-    //         this.lastPingTime = performance.now();
-    //         this.connection.send("PING");
-    //     }
-    // };
+    checkConnectionStatus = () => {
+        return this.connectionStatus;
+    }
 
     @action updateEndToEndPing = () => {
         this.endToEndPing = this.lastPongTime - this.lastPingTime;

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -359,17 +359,7 @@ export class MessageController {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
-            let tt2 = new Map<number, CARTA.IRegionStyle>().set(1, {name: "", color: "#2EE6D6", lineWidth: 2, dashList: []})
-            // console.log(tt2);
-            // console.log(regionStyles);
-            // console.log(directory, file, type, fileId, mapToObject(regionStyles), coordType)
-            // const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(tt2), coordType});
-            let directory = 'Users/ming-yi/carta-test-img/set_QA';
-            let file = 't4';
-            let type = 1;
-            let fileId = 0;
-            let coordType = 1;
-            const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(tt2), coordType});
+            const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(regionStyles), coordType});
             const requestId = this.eventCounter;
             this.logEvent(CARTA.EventType.EXPORT_REGION, requestId, message, false);
             if (this.sendEvent(CARTA.EventType.EXPORT_REGION, CARTA.ExportRegion.encode(message).finish())) {

--- a/src/test/MessageController.ts
+++ b/src/test/MessageController.ts
@@ -66,6 +66,7 @@ export class MessageController {
     public sessionId: number;
     public serverFeatureFlags: number;
     public serverUrl: string;
+    public count: number;
 
     private connection: WebSocket;
     private lastPingTime: number;
@@ -90,6 +91,7 @@ export class MessageController {
     private readonly decoderMap: Map<CARTA.EventType, {messageClass: any; handler: HandlerFunction}>;
 
     private constructor() {
+        this.count = 0;
         makeObservable(this);
         this.loggingEnabled = true;
         this.deferredMap = new Map<number, Deferred<IBackendResponse>>();
@@ -164,13 +166,10 @@ export class MessageController {
 
         const isReconnection: boolean = url === this.serverUrl;
         let connectionAttempts = 0;
-        // const apiService = ApiService.Instance;
         this.connectionDropped = false;
         this.connectionStatus = ConnectionStatus.PENDING;
         this.serverUrl = url;
         this.connection = new WebSocket(url);
-        // this.connection = new WebSocket(apiService.accessToken ? url + `?token=${apiService.accessToken}` : url);
-        // console.log(apiService.accessToken ? url + `?token=${apiService.accessToken}` : url);
         this.connection.binaryType = "arraybuffer";
         this.connection.onmessage = this.messageHandler.bind(this);
         this.connection.onclose = (ev: CloseEvent) =>
@@ -363,7 +362,17 @@ export class MessageController {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
-            const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(regionStyles), coordType});
+            let tt2 = new Map<number, CARTA.IRegionStyle>().set(1, {name: "", color: "#2EE6D6", lineWidth: 2, dashList: []})
+            // console.log(tt2);
+            // console.log(regionStyles);
+            // console.log(directory, file, type, fileId, mapToObject(regionStyles), coordType)
+            // const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(tt2), coordType});
+            let directory = 'Users/ming-yi/carta-test-img/set_QA';
+            let file = 't4';
+            let type = 1;
+            let fileId = 0;
+            let coordType = 1;
+            const message = CARTA.ExportRegion.create({directory, file, type, fileId, regionStyles: mapToObject(tt2), coordType});
             const requestId = this.eventCounter;
             this.logEvent(CARTA.EventType.EXPORT_REGION, requestId, message, false);
             if (this.sendEvent(CARTA.EventType.EXPORT_REGION, CARTA.ExportRegion.encode(message).finish())) {
@@ -381,7 +390,7 @@ export class MessageController {
         let file = input.file;
         let hdu = input.hdu;
         let fileId = input.fileId;
-        let imageArithmetic = input.lelExpr;
+        let imageArithmetic = input.lelExpr
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
@@ -971,8 +980,10 @@ export class MessageController {
         if (this.loggingEnabled) {
             if (incoming) {
                 if (eventId === 0) {
+                    this.messageReceiving(true);
                     // console.log(`<== ${eventName} [Stream]`);
                 } else {
+                    this.messageReceiving(true);
                     // console.log(`<== ${eventName} [${eventId}]`);
                 }
             } else {
@@ -980,6 +991,15 @@ export class MessageController {
             }
             // console.log(message);
             // console.log("\n");
+        }
+    }
+
+    public messageReceiving(set?: boolean): number {
+        if (set) {
+            this.count = this.count + 1;
+            return this.count;
+        } else {
+            return this.count;
         }
     }
 }

--- a/src/test/PER_CUBE_HISTOGRAM.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM.test.ts
@@ -1,0 +1,171 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    lengthOfHistogramBins: number;
+    binValues: { index: number, value: number }[];
+    mean: number;
+    stdDev: number;
+}
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    regionHistogramData: IRegionHistogramDataExt;
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    openFile: {
+        directory: testSubdirectory,
+        file: "supermosaic.10.fits",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+    regionHistogramData: {
+        regionId: -2,
+        channel: -2,
+        histograms: {
+            numBins: 2775,
+            binWidth: 0.7235205769538879,
+            firstBinCenter: -1773.2998046875,
+        },
+        lengthOfHistogramBins: 2775,
+        binValues: [{ index: 2500, value: 9359604 },],
+        mean: 18.742310255027036,
+        stdDev: 22.534721826342878,
+    },
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("PER_CUBE_HISTOGRAM: Testing calculations of the per-cube histogram", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+        }, openFileTimeout);
+
+        test(`return RASTER_TILE_DATA(Stream) and check total length | `, async () => {
+            msgController.addRequiredTiles(assertItem.addTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        let ReceiveProgress: number;
+        let RegionHistogramData: CARTA.RegionHistogramData;
+        let RegionHistogramDataTemp1 = []
+        describe(`Set histogram requirements:`, () => {
+            test(`(Step1) "${assertItem.openFile.file}" REGION_HISTOGRAM_DATA should arrive completely within 3000 ms:`, async () => {
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
+                RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+                ReceiveProgress = RegionHistogramData.progress;
+            }, 3000);
+
+            test(`(Step2) REGION_HISTOGRAM_DATA.progress > 0 and REGION_HISTOGRAM_DATA.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
+                expect(RegionHistogramData[0].progress).toBeGreaterThan(0);
+                expect(RegionHistogramData[0].regionId).toEqual(assertItem.regionHistogramData.regionId);
+            });
+
+            test("(Step3 & Step4) Assert and check REGION_HISTOGRAM_DATA as the progress be just greater than 0.5", async () => {
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            RegionHistogramDataTemp1.push(data)
+                            if (data.progress > 0.5) {
+                                resolve(RegionHistogramDataTemp1)
+                            }
+                        }
+                    })
+                });
+                
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                RegionHistogramData = regionHistogramDataResponse.slice(-1)[0]
+                ReceiveProgress = RegionHistogramData.progress;
+                expect(ReceiveProgress).toBeGreaterThanOrEqual(0.5);
+                expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                expect(RegionHistogramData.channel).toEqual(assertItem.regionHistogramData.channel);
+                expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+                expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
+            }, cubeHistogramTimeout);
+
+            test("(Step5) Assert and check REGION_HISTOGRAM_DATA as the progress be just greater than 1", async () => {
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            RegionHistogramDataTemp1.push(data)
+                            if (data.progress === 1) {
+                                resolve(RegionHistogramDataTemp1)
+                            }
+                        }
+                    })
+                });
+                
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                RegionHistogramData = regionHistogramDataResponse.slice(-1)[0]
+                ReceiveProgress = RegionHistogramData.progress;
+                expect(ReceiveProgress).toEqual(1);
+                expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                expect(RegionHistogramData.histograms.bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+                expect(RegionHistogramData.channel).toEqual(assertItem.regionHistogramData.channel);
+                expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+                expect(RegionHistogramData.histograms.mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+                expect(RegionHistogramData.histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+                expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
+            }, cubeHistogramTimeout);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -1,0 +1,182 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
+let messageReturnTimeout = config.timeout.readFile;
+let cancelTimeout = config.timeout.cancel;
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    lengthOfHistogramBins: number;
+    binValues: { index: number, value: number }[];
+    mean: number;
+    stdDev: number;
+}
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    cancelHistogramRequirements: CARTA.ISetHistogramRequirements;
+    regionHistogramData: IRegionHistogramDataExt;
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "SDC335.579-0.292.spw0-channel-cutted.line.fits",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+    cancelHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [],
+    },
+    regionHistogramData: {
+        regionId: -2,
+        channel: -2,
+        histograms: 
+        {
+            numBins: 342,
+            binWidth: 0.0007966686389409006,
+            firstBinCenter: -0.09137402474880219,
+        },
+        lengthOfHistogramBins: 342,
+        binValues: [{ index: 170, value: 10548 },],
+        mean: 0.00005560920907762894,
+        stdDev: 0.012523454128847715,
+    },
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("PER_CUBE_HISTOGRAM_CANCELLATION: Testing calculations of the per-cube histogram with cancellation", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+        }, openFileTimeout);
+
+        test(`Assert total length of RASTER_TILE_DATA(Stream)`, async () => {
+            msgController.addRequiredTiles(assertItem.addTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        let ReceiveProgress: number;
+        let RegionHistogramData: CARTA.RegionHistogramData;
+        let RegionHistogramDataTemp1 = []
+        describe(`Set histogram requirements:`, () => {
+            test(`(Step1) "${assertItem.openFile.file}" REGION_HISTOGRAM_DATA should arrive completely within 30000 ms:`, async () => {
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
+                RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+                ReceiveProgress = RegionHistogramData[0].progress;
+            }, 3000);
+
+            test(`(Step2) REGION_HISTOGRAM_DATA.progress > 0 and REGION_HISTOGRAM_DATA.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
+                expect(RegionHistogramData[0].progress).toBeGreaterThan(0);
+                expect(RegionHistogramData[0].regionId).toEqual(assertItem.regionHistogramData.regionId);
+                console.log('Step2 progress:', ReceiveProgress)
+            });
+
+            test(`(Step3) The second REGION_HISTOGRAM_DATA should arrive and REGION_HISTOGRAM_DATA.progress > previous one `, async () => {
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
+                RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+                ReceiveProgress = RegionHistogramData[0].progress;
+                console.log('' + assertItem.openFile.file + ' Region Histogram progress :', ReceiveProgress);
+            }, readFileTimeout);
+
+            test("(Step4) Assert no more REGION_HISTOGRAM_DATA returns", async () => {
+                /// After 5 seconds, the request of the per-cube histogram is cancelled.
+                await new Promise<void>(end => setTimeout(() => end(), cancelTimeout));
+                msgController.setHistogramRequirements(assertItem.cancelHistogramRequirements);
+                // Receive messages until get two ErrorData
+                let errorMessage = await Stream(CARTA.ErrorData, 2);
+                console.log(errorMessage);
+            }, readFileTimeout + messageReturnTimeout + cancelTimeout);
+
+            test("(Step5) Assert a renew REGION_HISTOGRAM_DATA as the progress = 1.0", async () => {
+                /// Then request to get the per-cube histogram again in 2 seconds.
+                await new Promise<void>(end => setTimeout(() => end(), 2000));
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            RegionHistogramDataTemp1.push(data)
+                            if (data.progress === 1) {
+                                resolve(RegionHistogramDataTemp1)
+                            }
+                        }
+                    })
+                });
+                
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                RegionHistogramData = regionHistogramDataResponse.slice(-1)[0]
+                ReceiveProgress = RegionHistogramData.progress;
+                expect(ReceiveProgress).toEqual(1);
+                expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                expect(RegionHistogramData.histograms.bins[170]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+                expect(RegionHistogramData.channel).toEqual(assertItem.regionHistogramData.channel);
+                expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+                expect(RegionHistogramData.histograms.mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+                expect(RegionHistogramData.histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+                expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
+            }, cubeHistogramTimeout);
+        });
+
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -117,11 +117,11 @@ describe("PER_CUBE_HISTOGRAM_CANCELLATION: Testing calculations of the per-cube 
         let RegionHistogramData: CARTA.RegionHistogramData;
         let RegionHistogramDataTemp1 = []
         describe(`Set histogram requirements:`, () => {
-            test(`(Step1) "${assertItem.openFile.file}" REGION_HISTOGRAM_DATA should arrive completely within 30000 ms:`, async () => {
+            test(`(Step1) "${assertItem.openFile.file}" REGION_HISTOGRAM_DATA should arrive completely within 5000 ms:`, async () => {
                 msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
                 RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
                 ReceiveProgress = RegionHistogramData[0].progress;
-            }, 3000);
+            }, 5000);
 
             test(`(Step2) REGION_HISTOGRAM_DATA.progress > 0 and REGION_HISTOGRAM_DATA.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
                 expect(RegionHistogramData[0].progress).toBeGreaterThan(0);

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
@@ -1,0 +1,164 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    lengthOfHistogramBins: number;
+    binValues: { index: number, value: number }[];
+    mean: number;
+    stdDev: number;
+}
+interface AssertItem {
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    regionHistogramData: IRegionHistogramDataExt;
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    openFile: {
+        directory: testSubdirectory,
+        file: "supermosaic.10.hdf5",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+    regionHistogramData: {
+        regionId: -2,
+        channel: -2,
+        histograms: 
+        {
+            numBins: 2775,
+            binWidth: 0.7235205573004645,
+            firstBinCenter: -1773.2998608150997,
+        },
+        lengthOfHistogramBins: 2775,
+        binValues: [{ index: 2500, value: 9359604 },],
+        mean: 18.742310241547514,//18.742310241547514 for socketdev; 18.743059611332498 for socketicd
+        stdDev: 22.534722680160574,//22.534722680160574 for socketdev; 22.376087536494833 for socketicd
+    },
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("PER_CUBE_HISTOGRAM_HDF5: Testing calculations of the per-cube histogram of hdf5", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms | `, async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+            let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+            expect(OpenFileResponse.success).toBe(true);
+            expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+        }, openFileTimeout);
+
+        test(`Assert total length of RASTER_TILE_DATA(Stream)`, async () => {
+            msgController.addRequiredTiles(assertItem.addTilesReq);
+            let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq.tiles.length + 2);
+
+            msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            expect(RasterTileDataResponse.length).toEqual(3); //RasterTileSync: start & end + 1 Tile returned
+        }, readFileTimeout);
+
+        let ReceiveProgress: number;
+        let RegionHistogramData: CARTA.RegionHistogramData;
+        let RegionHistogramDataTemp1 = []
+        describe(`Set histogram requirements:`, () => {
+            test(`REGION_HISTOGRAM_DATA should arrive completely within ${cubeHistogramTimeout} ms:`, async () => {
+                msgController.setHistogramRequirements(assertItem.setHistogramRequirements);
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            RegionHistogramDataTemp1.push(data)
+                            if (data.progress === 1) {
+                                resolve(RegionHistogramDataTemp1)
+                            }
+                        }
+                    })
+                });
+                
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                RegionHistogramData = regionHistogramDataResponse.slice(-1)[0]
+                ReceiveProgress = RegionHistogramData.progress;
+            }, cubeHistogramTimeout);
+
+            test(`Assert REGION_HISTOGRAM_DATA.progress == 1`, () => {
+                expect(ReceiveProgress).toBe(1);
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.bin_width = ${assertItem.regionHistogramData.histograms.binWidth}`, () => {
+                expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+            });
+    
+            test(`Assert len(REGION_HISTOGRAM_DATA.histograms.bins) = ${assertItem.regionHistogramData.lengthOfHistogramBins}`, () => {
+                expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.bins[2500] = 9359604`, () => {
+                expect(RegionHistogramData.histograms.bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.firt_bin_center = ${assertItem.regionHistogramData.histograms.firstBinCenter}`, () => {
+                expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.num_bins = ${assertItem.regionHistogramData.histograms.numBins}`, () => {
+                expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.mean = ${assertItem.regionHistogramData.mean}`, () => {
+                expect(RegionHistogramData.histograms.mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.stdDev = ${assertItem.regionHistogramData.stdDev}`, () => {
+                expect(RegionHistogramData.histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+            });
+    
+            test(`Assert REGION_HISTOGRAM_DATA.histograms.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
+                expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_CANCEL.test.ts
+++ b/src/test/PV_GENERATOR_CANCEL.test.ts
@@ -191,7 +191,7 @@ describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
                 let regionHistogramDataResponse = await regionHistogramDataPromise;
                 expect(PVresponse.success).toBe(true);
                 expect(regionHistogramDataResponse.length).toBe(1);
-            }, 10000);
+            }, PVTimeout);
 
             test(`(Step 7 & 8): request 2 tiles after PV response`, async()=>{
                 msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);

--- a/src/test/PV_GENERATOR_CANCEL.test.ts
+++ b/src/test/PV_GENERATOR_CANCEL.test.ts
@@ -1,0 +1,251 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let PVTimeout: number = config.timeout.pvRequest;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest;
+    imageDataIndex: number[];
+    imageData1: number[];
+    imageDataSequence1: number[];
+    imageData2: number[];
+    imageDataSequence2: number[];
+    stopPV: CARTA.IStopPvCalc;
+    pvCancelMessage: string;
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 175, y: 125 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 1000,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 79, y: 77 }, { x: 362, y: 360 }],
+                rotation: 135,
+            }
+        },
+    ],
+    setPVRequest: {
+        fileId:0,
+        regionId:1,
+        width:3,
+    },
+    imageDataIndex: [0,2500,5000,7500,10000,15000,20000,25000],
+    imageData1: [241,125,53,100,216,50,129,121],
+    imageDataSequence1: [83,243,72,117,76,88,203,166,92,176,89],
+    imageData2: [241,165,145,83,25,175,7,188],
+    imageDataSequence2: [105,233,60,28,2,164,208,104,130,43,234],    
+    stopPV: {
+        fileId: 0
+    },
+    pvCancelMessage: "PV image generator cancelled"
+};
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms)).then(() => { console.log('sleep!') });
+}
+
+let basepath: string;
+describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`(step 1): Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            });
+
+            test(`(step 2): set cursor and add required tiles`, async () => {
+                msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): set SET_SPATIAL_REQUIREMENTS`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`(Step 4): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let pvProgressArray = [];
+            let pvProgressReponse : any;
+            let pvResponse : any;
+            let count = 0;
+            test(`(Step 5): PV Request, halt PV when received 3 pvProgress Stream and check cancel`, async()=>{
+                let pvProgressPromise = new Promise((resolve)=>{
+                    msgController.pvProgressStream.subscribe({
+                        next: (data) => {
+                            count++;
+                            console.warn('request ' + assertItem.openFile.file + ' PV response progress :', data.progress);
+                            pvProgressArray.push(data)
+                            if (count == 3) {
+                                msgController.cancelRequestingPV(assertItem.setPVRequest.fileId);
+                                resolve(pvProgressArray);
+                            }
+                        }
+                    })
+                });
+                try {
+                    pvResponse = await msgController.requestPV(assertItem.setPVRequest);
+                } catch (err) {
+                    expect(err).toContain(assertItem.pvCancelMessage);
+                } 
+                pvProgressReponse = await pvProgressPromise
+            },PVTimeout);
+
+            let regionHistogramData = [];
+            test(`(Step 6): Request PV Request again`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                await sleep(5000);
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(PVresponse.success).toBe(true);
+                expect(regionHistogramDataResponse.length).toBe(1);
+            }, 10000);
+
+            test(`(Step 7 & 8): request 2 tiles after PV response`, async()=>{
+                msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);
+                let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileDataResponse2 = await Stream(CARTA.RasterTileData, assertItem.addTilesReq[1].tiles.length + 2);
+                let Tile1 = RasterTileDataResponse2[1];
+                let Tile2 = RasterTileDataResponse2[2];
+
+                if (Tile1.tiles[0].width === 145) {
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(145);
+                    expect(Tile1.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(256);
+                    expect(Tile2.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                } else if (Tile1.tiles[0].width === 256) {
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(145);
+                    expect(Tile2.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(256);
+                    expect(Tile1.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                }
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_CASA.test.ts
+++ b/src/test/PV_GENERATOR_CASA.test.ts
@@ -1,0 +1,215 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let PVTimeout: number = config.timeout.pvRequest;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest;
+    imageDataIndex: number[];
+    imageData1: number[];
+    imageDataSequence1: number[];
+    imageData2: number[];
+    imageDataSequence2: number[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.image",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 175, y: 125 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 1000,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 79, y: 77 }, { x: 362, y: 360 }],
+                rotation: 135,
+            }
+        },
+    ],
+    setPVRequest: {
+        fileId:0,
+        regionId:1,
+        width:3,
+    },
+    imageDataIndex: [0,2500,5000,7500,10000,15000,20000,25000],
+    imageData1: [241,125,53,100,216,50,129,121],
+    imageDataSequence1: [83,243,72,117,76,88,203,166,92,176,89],
+    imageData2: [241,165,145,83,25,175,7,188],
+    imageDataSequence2: [105,233,60,28,2,164,208,104,130,43,234],
+};
+
+let basepath: string;
+describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`(step 1): Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            });
+
+            test(`(step 2): set cursor and add required tiles`, async () => {
+                msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): set SET_SPATIAL_REQUIREMENTS`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`(Step 4): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let regionHistogramData = [];
+            test(`(Step 5): PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(PVresponse.success).toBe(true);
+                expect(regionHistogramDataResponse.length).toBe(1);
+            },PVTimeout);
+
+            test(`(Step 6 & 7): request 2 tiles after PV response`, async()=>{
+                msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);
+                let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileDataResponse2 = await Stream(CARTA.RasterTileData, assertItem.addTilesReq[1].tiles.length + 2);
+                let Tile1 = RasterTileDataResponse2[1];
+                let Tile2 = RasterTileDataResponse2[2];
+
+                if (Tile1.tiles[0].width === 145) {
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(145);
+                    expect(Tile1.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(256);
+                    expect(Tile2.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                } else if (Tile1.tiles[0].width === 256) {
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(145);
+                    expect(Tile2.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(256);
+                    expect(Tile1.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                }
+
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_FITS.test.ts
+++ b/src/test/PV_GENERATOR_FITS.test.ts
@@ -1,0 +1,214 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let PVTimeout: number = config.timeout.pvRequest;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest;
+    imageDataIndex: number[];
+    imageData1: number[];
+    imageDataSequence1: number[];
+    imageData2: number[];
+    imageDataSequence2: number[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 175, y: 125 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 1000,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 79, y: 77 }, { x: 362, y: 360 }],
+                rotation: 135,
+            }
+        },
+    ],
+    setPVRequest: {
+        fileId:0,
+        regionId:1,
+        width:3,
+    },
+    imageDataIndex: [0,2500,5000,7500,10000,15000,20000,25000],
+    imageData1: [241,125,53,100,216,50,129,121],
+    imageDataSequence1: [83,243,72,117,76,88,203,166,92,176,89],
+    imageData2: [241,165,145,83,25,175,7,188],
+    imageDataSequence2: [105,233,60,28,2,164,208,104,130,43,234],
+};
+
+let basepath: string;
+describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`(step 1): Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            });
+
+            test(`(step 2): set cursor and add required tiles`, async () => {
+                msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): set SET_SPATIAL_REQUIREMENTS`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`(Step 4): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let regionHistogramData = [];
+            test(`(Step 5): PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(PVresponse.success).toBe(true);
+                expect(regionHistogramDataResponse.length).toBe(1);
+            },PVTimeout);
+
+            test(`(Step 6 & 7): request 2 tiles after PV response`, async()=>{
+                msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);
+                let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileDataResponse2 = await Stream(CARTA.RasterTileData, assertItem.addTilesReq[1].tiles.length + 2);
+                let Tile1 = RasterTileDataResponse2[1];
+                let Tile2 = RasterTileDataResponse2[2];
+
+                if (Tile1.tiles[0].width === 145) {
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(145);
+                    expect(Tile1.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(256);
+                    expect(Tile2.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                } else if (Tile1.tiles[0].width === 256) {
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(145);
+                    expect(Tile2.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(256);
+                    expect(Tile1.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                }
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_HDF5_COMPARED_FITS.test.ts
+++ b/src/test/PV_GENERATOR_HDF5_COMPARED_FITS.test.ts
@@ -1,0 +1,358 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let readTimeout: number = config.timeout.readFile;
+let PVTimeout: number = config.timeout.pvRequest;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile[];
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest[];
+    imageDataIndex: number[];
+    imageData1: number[];
+    imageDataSequence1: number[];
+    imageData2: number[];
+    imageDataSequence2: number[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: [
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.hdf5",
+            hdu: "0",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.fits",
+            hdu: "0",
+            fileId: 2,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+        {
+            fileId: 2,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 3000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 175, y: 125 },
+        },
+        {
+            fileId: 2,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 177, y: 79 },
+        },
+        {
+            fileId: 3000,
+            point: { x: 177, y: 79 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 79, y: 77 }, { x: 362, y: 360 }],
+                rotation: 135,
+            }
+        },
+        {
+            fileId: 2,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 79, y: 77 }, { x: 362, y: 360 }],
+                rotation: 135,
+            }
+        },
+    ],
+    setPVRequest: [
+        {
+            fileId:0,
+            regionId:1,
+            width:3,
+        },
+        {
+            fileId:2,
+            regionId:2,
+            width:3,
+        },
+    ],
+    imageDataIndex: [0,2500,5000,7500,10000,15000,20000,25000],
+    imageData1: [241,125,53,100,216,50,129,121],
+    imageDataSequence1: [83,243,72,117,76,88,203,166,92,176,89],
+    imageData2: [241,165,145,83,25,175,7,188],
+    imageDataSequence2: [105,233,60,28,2,164,208,104,130,43,234],
+};
+
+let basepath: string;
+describe("PV_GENERATOR_HDF5_COMPARED_FITS:Testing PV generator with hdf5 file and comparing hdf5 file result to fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder and open "${assertItem.openFile[0].file}`, () => {
+            test(`(step 1): Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile[0]);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[0].file);
+            });
+
+            test(`(step 2): set cursor and add required tiles`, async () => {
+                msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): set SET_SPATIAL_REQUIREMENTS`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`(Step 4): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let regionHistogramData = [];
+            test(`(Step 5): PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest[0]);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(PVresponse.success).toBe(true);
+                expect(regionHistogramDataResponse.length).toBe(1);
+            },PVTimeout);
+
+            test(`(Step 6 & 7): request 2 tiles after PV response`, async()=>{
+                msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);
+                let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileDataResponse2 = await Stream(CARTA.RasterTileData, assertItem.addTilesReq[1].tiles.length + 2);
+                let Tile1 = RasterTileDataResponse2[1];
+                let Tile2 = RasterTileDataResponse2[2];
+
+                if (Tile1.tiles[0].width === 145) {
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(145);
+                    expect(Tile1.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(256);
+                    expect(Tile2.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                } else if (Tile1.tiles[0].width === 256) {
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(145);
+                    expect(Tile2.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(256);
+                    expect(Tile1.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                }
+            });
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder and open "${assertItem.openFile[1].file}"`, () => {
+            test(`(step 8): Open File`,async () => {
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile[1]);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[1].file)
+                expect(RegionHistogramData[0].fileId).toEqual(2);
+            }, readTimeout);
+
+            test(`(step 9): set cursor and add required tiles`, async()=>{
+                msgController.setCursor(assertItem.setCursor[2].fileId, assertItem.setCursor[2].point.x, assertItem.setCursor[2].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[2]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[2].tiles.length + 2);
+            });
+
+            test(`(Step 10): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[1].fileId, assertItem.setRegion[1].regionId, assertItem.setRegion[1].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(2);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let regionHistogramData = [];
+            test(`(Step 11): PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest[1]);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(PVresponse.success).toBe(true);
+                expect(regionHistogramDataResponse.length).toBe(1);
+            },PVTimeout);
+
+            test(`(Step 12): request 2 tiles after PV response`, async()=>{
+                msgController.addRequiredTiles(assertItem.addTilesReq[3]);
+                let RasterTileDataResponse2 = await Stream(CARTA.RasterTileData, assertItem.addTilesReq[1].tiles.length + 2);
+                let Tile1 = RasterTileDataResponse2[1];
+                let Tile2 = RasterTileDataResponse2[2];
+    
+                if (Tile1.tiles[0].width === 145) {
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(145);
+                    expect(Tile1.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(256);
+                    expect(Tile2.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                } else if (Tile1.tiles[0].width === 256) {
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(145);
+                    expect(Tile2.tiles[0].x).toEqual(1);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData1[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+18800]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+    
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(256);
+                    expect(Tile1.tiles[0].height).toEqual(250);
+                    for (let i=0; i<assertItem.imageData1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+35500]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                }
+            });
+
+            test(`(Step 13): set SET_REGION`,async()=>{
+                msgController.setCursor(assertItem.setCursor[3].fileId, assertItem.setCursor[3].point.x, assertItem.setCursor[3].point.y);
+                let hdf5PVCursorValue = await Stream(CARTA.SpatialProfileData, 1);
+                msgController.setCursor(assertItem.setCursor[4].fileId, assertItem.setCursor[4].point.x, assertItem.setCursor[4].point.y);
+                let fitsPVCursorValue = await Stream(CARTA.SpatialProfileData, 1);
+                expect(hdf5PVCursorValue.value).toEqual(fitsPVCursorValue.value)
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_MATCH_SPATIAL.test.ts
+++ b/src/test/PV_GENERATOR_MATCH_SPATIAL.test.ts
@@ -1,0 +1,219 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let readTimeout: number = config.timeout.readFile;
+let PVTimeout: number = config.timeout.pvRequest;
+let Match2ImageTimeout: number = 30000;
+
+interface SpatialProfileDataExtend extends CARTA.ISpatialProfileData {
+    index?: number[];
+    indexValue?: number[];
+}
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile[];
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest[];
+    returnPVSpatial: SpatialProfileDataExtend;
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: [
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.fits",
+            hdu: "0",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HD163296_CO_2_1.image",
+            hdu: "0",
+            fileId: 1,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+
+    ],
+    setSpatialReq: [
+        {
+            fileId: 1,
+            regionId: 0,
+            spatialProfiles: []
+        },
+        {
+            fileId: 1,
+            regionId: 1,
+            spatialProfiles: [{coordinate:"", mip:1, width:3}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 79, y: 77 }, { x: 362, y: 360 }],
+                rotation: 135,
+            }
+        },
+    ],
+    setPVRequest: [
+        {
+            fileId:0,
+            regionId:1,
+            width:3,
+        },
+        {
+            fileId:1,
+            regionId:1,
+            width:3,
+        },
+    ],
+    returnPVSpatial: {
+        fileId:1,
+        regionId:1,
+        profiles: [{coordinate:"", start: 0, end: 400}],
+        index: [100, 500, 1000, 1500],
+        indexValue: [85, 10, 220, 106],
+    }
+};
+
+let basepath: string;
+describe("PV_GENERATOR_MATCH_SPATIAL:Testing PV generator with two spatially matched images.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder and open "${assertItem.openFile[0].file}" & "${assertItem.openFile[1].file}"`, () => {
+            test(`(step 1): Open the first image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile[0]);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[0].file);
+                expect(RegionHistogramData[0].fileId).toEqual(0);
+            });
+
+            test(`(step 2): set cursor and add required tiles to the first image`, async()=>{
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): Open the second image`,async () => {
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile[1]);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+                expect(OpenFileResponse.success).toEqual(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile[1].file)
+                expect(RegionHistogramData[0].fileId).toEqual(1);
+            }, readTimeout);
+
+            test(`(step 4): set cursor and add required tiles to the second image`, async()=>{
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[1].tiles.length + 2);
+            });
+
+            test(`(Step 5): set SET_REGION to the first image`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            test(`(step 6): Match the first image to the second image`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[1]);
+                let Response = await Stream(CARTA.SpatialProfileData,1);
+                expect(Response[0].fileId).toEqual(assertItem.returnPVSpatial.fileId);
+                expect(Response[0].regionId).toEqual(assertItem.returnPVSpatial.regionId);
+                expect(Response[0].profiles[0].coordinate).toEqual(assertItem.returnPVSpatial.profiles[0].coordinate);
+                expect(Response[0].profiles[0].start).toEqual(assertItem.returnPVSpatial.profiles[0].start);
+                expect(Response[0].profiles[0].end).toEqual(assertItem.returnPVSpatial.profiles[0].end);
+                assertItem.returnPVSpatial.index.map((reference, index) => {
+                    expect(Response[0].profiles[0].rawValuesFp32[reference]).toEqual(assertItem.returnPVSpatial.indexValue[index]);
+                })
+            }, Match2ImageTimeout);
+
+            let regionHistogramData = [];
+            test(`(Step 7): 1st image PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest[0]);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+
+                expect(regionHistogramDataResponse[0].fileId).toEqual(1000);
+                expect(regionHistogramDataResponse[0].regionId).toEqual(-1);
+                expect(regionHistogramDataResponse[0].progress).toEqual(1);
+                expect(PVresponse.openFileAck.fileId).toEqual(1000);
+                expect(PVresponse.openFileAck.fileInfo.name).toEqual("HD163296_CO_2_1_pv.fits");
+                expect(PVresponse.success).toEqual(true)
+            }, PVTimeout);
+
+            let regionHistogramData2 = [];
+            test(`(Step 7): 2nd image PV Request`, async()=>{
+                let regionHistogramDataPromise2 = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData2.push(data)
+                            resolve(regionHistogramData2)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest[1]);
+                let regionHistogramDataResponse = await regionHistogramDataPromise2;
+                expect(regionHistogramDataResponse[0].fileId).toEqual(2000);
+                expect(regionHistogramDataResponse[0].regionId).toEqual(-1);
+                expect(regionHistogramDataResponse[0].progress).toEqual(1);
+                expect(PVresponse.openFileAck.fileId).toEqual(2000);
+                expect(PVresponse.openFileAck.fileInfo.name).toEqual("HD163296_CO_2_1_pv.image");
+                expect(PVresponse.success).toEqual(true)
+            }, PVTimeout);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_NaN.test.ts
+++ b/src/test/PV_GENERATOR_NaN.test.ts
@@ -1,0 +1,221 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let readTimeout: number = config.timeout.readFile;
+let PVTimeout: number = config.timeout.pvRequest;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest;
+    imageDataIndex2: number[];
+    imageDataSequence1: number[];
+    imageData2: number[];
+    imageDataSequence2: number[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 260, y: 11 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 64, y: 8 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 1000,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: -54, y: 325 }, { x: 206, y: 325 }],
+                rotation: 90,
+            }
+        },
+    ],
+    setPVRequest: {
+        fileId:0,
+        regionId:1,
+        width:3,
+    },
+    imageDataSequence1: [0,0,0,0,0,0,0,0],
+    imageDataIndex2: [0,500,1000,1500,2000,3000],
+    imageData2: [241,77,63,201,254,220],
+    imageDataSequence2: [245,112,51,42,145,32,151,35,241,6,107]
+};
+
+let basepath: string;
+describe("PV_GENERATOR_NaN:Testing PV generator with a region covers NaN and none pixel.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+            test(`(step 1): Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            }, readTimeout);
+
+            test(`(step 2): set cursor and add required tiles`, async () => {
+                msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): set SET_SPATIAL_REQUIREMENTS`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`(Step 4): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let regionHistogramData = [];
+            test(`(Step 5): PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(PVresponse.success).toBe(true);
+                expect(regionHistogramDataResponse.length).toBe(1);
+            },PVTimeout);
+
+            test(`(Step 6 & 7): request 2 tiles after PV response`, async()=>{
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileDataResponse2 = await Stream(CARTA.RasterTileData, assertItem.addTilesReq[1].tiles.length + 2);
+                let Tile1 = RasterTileDataResponse2[1];
+                let Tile2 = RasterTileDataResponse2[2];
+
+                if (Tile1.tiles[0].width === 5) {
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(5);
+                    expect(Tile1.tiles[0].height).toEqual(25);
+                    expect(Tile1.tiles[0].x).toEqual(1);
+                    for (let i = 0; i < assertItem.imageDataSequence1.length; i++) {
+                        expect(Tile1.tiles[0].imageData[i]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+                
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(256);
+                    expect(Tile2.tiles[0].height).toEqual(25);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile2.tiles[0].imageData[assertItem.imageDataIndex2[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile2.tiles[0].imageData[i+2510]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                } else if (Tile1.tiles[0].width === 256){
+                    expect(Tile2.tiles[0].layer).toEqual(1);
+                    expect(Tile2.tiles[0].width).toEqual(5);
+                    expect(Tile2.tiles[0].height).toEqual(25);
+                    expect(Tile2.tiles[0].x).toEqual(1);
+                    for (let i = 0; i < assertItem.imageDataSequence1.length; i++) {
+                        expect(Tile2.tiles[0].imageData[i]).toEqual(assertItem.imageDataSequence1[i]);
+                    }
+                
+                    expect(Tile1.tiles[0].layer).toEqual(1);
+                    expect(Tile1.tiles[0].width).toEqual(256);
+                    expect(Tile1.tiles[0].height).toEqual(25);
+                    for (let i=0; i<assertItem.imageData2.length; i++) {
+                        expect(Tile1.tiles[0].imageData[assertItem.imageDataIndex2[i]]).toEqual(assertItem.imageData2[i]);
+                    }
+                    for (let i = 0; i <= 10; i++) {
+                        expect(Tile1.tiles[0].imageData[i+2510]).toEqual(assertItem.imageDataSequence2[i]);
+                    }
+                }
+            });
+            test(`(step 8): set cursor and check the return value`, async()=>{
+                msgController.setCursor(assertItem.setCursor[1].fileId, assertItem.setCursor[1].point.x, assertItem.setCursor[1].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData, 1);
+                expect(SpatialProfileDataResponse1[0].fileId).toEqual(1000);
+                expect(SpatialProfileDataResponse1[0].value).toEqual(NaN);
+
+                msgController.setCursor(assertItem.setCursor[2].fileId, assertItem.setCursor[2].point.x, assertItem.setCursor[2].point.y);
+                let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData, 1);
+                expect(SpatialProfileDataResponse2[0].fileId).toEqual(1000);
+                expect(SpatialProfileDataResponse2[0].value).toEqual(-0.0035615740343928337);
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/PV_GENERATOR_WIDE.test.ts
+++ b/src/test/PV_GENERATOR_WIDE.test.ts
@@ -1,0 +1,200 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let PVTimeout: number = config.timeout.pvRequest;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor[];
+    setSpatialReq: CARTA.ISetSpatialRequirements[];
+    setRegion: CARTA.ISetRegion[];
+    setPVRequest: CARTA.IPvRequest[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "Gaussian-cutted.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1000,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16777217],
+        },
+    ],
+    setCursor: [
+        {
+            fileId: 0,
+            point: { x: 1, y: 1 },
+        },
+        {
+            fileId: 1000,
+            point: { x: 175, y: 125 },
+        },
+    ],
+    setSpatialReq: [
+        {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+        {
+            fileId: 1000,
+            regionId: 0,
+            spatialProfiles: [{coordinate:"x", mip:1}, {coordinate:"y", mip:1}]
+        },
+    ],
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 74, y: 190 }, { x: 164, y: 190 }],
+                rotation: 90,
+            }
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.LINE,
+                controlPoints: [{ x: 769, y: 190 }, { x: 859, y: 190 }],
+                rotation: 90,
+            }
+        },
+    ],
+    setPVRequest: [
+        {
+            fileId:0,
+            regionId:1,
+            width:3,
+        },
+        {
+            fileId:0,
+            regionId:2,
+            width:3,
+        }
+    ],
+};
+
+let basepath: string;
+describe("PV_GENERATOR_WIDE:Testing PV generator with wide (~all sky) image", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Preparation`, () => {
+            test(`(step 1): Open image`, async () => {
+                msgController.closeFile(-1);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let RegionHistogramData = await Stream(CARTA.RegionHistogramData,1);
+
+                expect(OpenFileResponse.success).toBe(true);
+                expect(OpenFileResponse.fileInfo.name).toEqual(assertItem.openFile.file);
+            });
+
+            test(`(step 2): set cursor and add required tiles`, async () => {
+                msgController.setCursor(assertItem.setCursor[0].fileId, assertItem.setCursor[0].point.x, assertItem.setCursor[0].point.y);
+                let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
+                let RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.addTilesReq[0].tiles.length + 2);
+            });
+
+            test(`(step 3): set SET_SPATIAL_REQUIREMENTS`, async()=>{
+                msgController.setSpatialRequirements(assertItem.setSpatialReq[0]);
+                let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+            });
+
+            test(`(Step 4): set SET_REGION`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[0].fileId, assertItem.setRegion[0].regionId, assertItem.setRegion[0].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(1);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            let regionHistogramData = [];
+            test(`(Step 5): PV Request`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let PVresponse = await msgController.requestPV(assertItem.setPVRequest[0]);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(regionHistogramDataResponse[0].fileId).toEqual(1000);
+                expect(regionHistogramDataResponse[0].progress).toEqual(1);
+                expect(regionHistogramDataResponse[0].regionId).toEqual(-1);
+                expect(PVresponse.openFileAck.fileId).toEqual(1000);
+                expect(PVresponse.openFileAck.fileInfoExtended.height).toEqual(16);
+                expect(PVresponse.openFileAck.fileInfoExtended.width).toEqual(182);
+                expect(PVresponse.openFileAck.fileInfo.name).toEqual("Gaussian-cutted_pv.fits");
+                expect(PVresponse.success).toEqual(true);
+            },PVTimeout);
+
+            test(`(Step 6): set the second region`,async()=>{
+                let setRegionAckResponse = await msgController.setRegion(assertItem.setRegion[1].fileId, assertItem.setRegion[1].regionId, assertItem.setRegion[1].regionInfo);
+                expect(setRegionAckResponse.regionId).toEqual(2);
+                expect(setRegionAckResponse.success).toEqual(true);
+            });
+
+            test(`(Step 7): PV Request for the second region`, async()=>{
+                let regionHistogramDataPromise = new Promise((resolve)=>{
+                    msgController.histogramStream.subscribe({
+                        next: (data) => {
+                            regionHistogramData.push(data)
+                            resolve(regionHistogramData)
+                        }
+                    })
+                });
+                let finalPVResponse = await msgController.requestPV(assertItem.setPVRequest[1]);
+                let regionHistogramDataResponse = await regionHistogramDataPromise;
+                expect(regionHistogramDataResponse[0].fileId).toEqual(1000);
+                expect(regionHistogramDataResponse[0].progress).toEqual(1);
+                expect(regionHistogramDataResponse[0].regionId).toEqual(-1);
+                expect(finalPVResponse.openFileAck.fileId).toEqual(1000);
+                expect(finalPVResponse.openFileAck.fileInfoExtended.height).toEqual(16);
+                expect(finalPVResponse.openFileAck.fileInfoExtended.width).toEqual(94);
+                expect(finalPVResponse.openFileAck.fileInfo.name).toEqual("Gaussian-cutted_pv.fits");
+                expect(finalPVResponse.success).toEqual(true);
+            },PVTimeout);
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/REGION_STATISTICS_ELLIPSE.test.ts
+++ b/src/test/REGION_STATISTICS_ELLIPSE.test.ts
@@ -1,0 +1,280 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let regionTimeout = config.timeout.region;
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile[];
+    addRequiredTiles: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setRegion: CARTA.ISetRegion[];
+    regionAck: CARTA.ISetRegionAck[];
+    setStatsRequirements: CARTA.ISetStatsRequirements[];
+    regionStatsData: CARTA.IRegionStatsData[];
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    openFile:
+        [
+            {
+                directory: testSubdirectory,
+                file: "M17_SWex.image",
+                fileId: 0,
+                hdu: "0",
+                renderMode: CARTA.RenderMode.RASTER,
+            },
+            {
+                directory: testSubdirectory,
+                file: "M17_SWex.hdf5",
+                fileId: 0,
+                hdu: "0",
+                renderMode: CARTA.RenderMode.RASTER,
+            },
+        ],
+    addRequiredTiles: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "ellipse_1",
+                regionType: CARTA.RegionType.ELLIPSE,
+                controlPoints: [{ x: 114, y: 545 }, { x: 4, y: 2 }],
+                rotation: 0.0,
+            }
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "ellipse_2",
+                regionType: CARTA.RegionType.ELLIPSE,
+                controlPoints: [{ x: 83, y: 489 }, { x: 4, y: 3 }],
+                rotation: 30.0,
+            },
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "ellipse_3",
+                regionType: CARTA.RegionType.ELLIPSE,
+                controlPoints: [{ x: 0, y: 486 }, { x: 4, y: 3 }],
+                rotation: 30.0,
+            },
+        },
+    ],
+    regionAck: [
+        {
+            success: true,
+            regionId: 1,
+        },
+        {
+            success: true,
+            regionId: 2,
+        },
+        {
+            success: true,
+            regionId: 3,
+        },
+    ],
+    setStatsRequirements: [
+        {
+            fileId: 0,
+            regionId: 1,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 2,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 3,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+    ],
+    regionStatsData: [
+        {
+            regionId: 1,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 24 },
+                { statsType: CARTA.StatsType.Sum, value: 0.18536625 },
+                { statsType: CARTA.StatsType.FluxDensity, value: 0.00851618 },
+                { statsType: CARTA.StatsType.Mean, value: 0.00772359 },
+                { statsType: CARTA.StatsType.RMS, value: 0.01397174 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.01189324 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.00468503 },
+                { statsType: CARTA.StatsType.Min, value: -0.01768329 },
+                { statsType: CARTA.StatsType.Max, value: 0.02505673 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.02505672 },
+            ]
+        },
+        {
+            regionId: 2,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 18 },
+                { statsType: CARTA.StatsType.Sum, value: 0.00485459 },
+                { statsType: CARTA.StatsType.FluxDensity, value: 0.00022303 },
+                { statsType: CARTA.StatsType.Mean, value: 0.0002697 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00307906 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.00315614 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.00017065 },
+                { statsType: CARTA.StatsType.Min, value: -0.00590614 },
+                { statsType: CARTA.StatsType.Max, value: 0.00654556 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.00654555 },
+            ]
+        },
+        {
+            regionId: 3,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 0 },
+                { statsType: CARTA.StatsType.Sum, value: NaN },
+                { statsType: CARTA.StatsType.FluxDensity, value: NaN },
+                { statsType: CARTA.StatsType.Mean, value: NaN },
+                { statsType: CARTA.StatsType.RMS, value: NaN },
+                { statsType: CARTA.StatsType.Sigma, value: NaN },
+                { statsType: CARTA.StatsType.SumSq, value: NaN },
+                { statsType: CARTA.StatsType.Min, value: NaN },
+                { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
+            ]
+        },
+    ],
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("REGION_STATISTICS_ELLIPSE: Testing statistics with ellipse regions", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
+        });
+
+        assertItem.openFile.map(openFile => {
+            describe(`Open image "${openFile.file}" to set image view`, () => {
+                test(`Preparation: Open image`,async () => {
+                    msgController.closeFile(-1);
+                    let OpenFileResponse = await msgController.loadFile(openFile);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                    msgController.addRequiredTiles(assertItem.addRequiredTiles);
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                });
+
+                assertItem.setRegion.map((region, index) => {
+                    if (region.regionId) {
+                        describe(`${region.regionId < 0 ? "Creating" : "Modify"} ${CARTA.RegionType[region.regionInfo.regionType]} region #${assertItem.regionAck[index].regionId} on ${JSON.stringify(region.regionInfo.controlPoints)}`, () => {
+                            let SetRegionAck: any;
+                            test(`SET_REGION_ACK should return within ${regionTimeout} ms`, async () => {
+                                SetRegionAck = await msgController.setRegion(region.fileId, region.regionId, region.regionInfo);
+                                // await Connection.send(CARTA.SetRegion, region);
+                                // SetRegionAck = await Connection.receive(CARTA.SetRegionAck);
+                            }, regionTimeout);
+    
+                            test(`SET_REGION_ACK.success = ${assertItem.regionAck[index].success}`, () => {
+                                expect(SetRegionAck.success).toBe(assertItem.regionAck[index].success);
+                            });
+    
+                            test(`SET_REGION_ACK.region_id = ${assertItem.regionAck[index].regionId}`, () => {
+                                expect(SetRegionAck.regionId).toEqual(assertItem.regionAck[index].regionId);
+                            });
+    
+                        });
+                    };
+    
+                    describe(`SET STATS REQUIREMENTS on ${CARTA.RegionType[region.regionInfo.regionType]} region #${assertItem.regionAck[index].regionId}`, () => {
+                        let RegionStatsData: any;
+                        test(`REGION_STATS_DATA should return within ${regionTimeout} ms`, async () => {
+                            await msgController.setStatsRequirements(assertItem.setStatsRequirements[index]);
+                            RegionStatsData = await Stream(CARTA.RegionStatsData,1);
+                        }, regionTimeout);
+    
+                        test(`REGION_STATS_DATA.region_id = ${assertItem.regionStatsData[index].regionId}`, () => {
+                            expect(RegionStatsData[0].regionId).toEqual(assertItem.regionStatsData[index].regionId);
+                        });
+    
+                        test("Assert & Check REGION_STATS_DATA.statistics", () => {
+                            assertItem.regionStatsData[index].statistics.map(stats => {
+                                if (isNaN(stats.value)) {
+                                    expect(isNaN(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value)).toBe(true);
+                                } else {
+                                    expect(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value).toBeCloseTo(stats.value, assertItem.precisionDigits);
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/REGION_STATISTICS_POLYGON.test.ts
+++ b/src/test/REGION_STATISTICS_POLYGON.test.ts
@@ -1,0 +1,412 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let regionTimeout = config.timeout.region;
+
+interface AssertItem {
+    openFile: CARTA.IOpenFile[];
+    addRequiredTiles: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setRegion: CARTA.ISetRegion[];
+    regionAck: CARTA.ISetRegionAck[];
+    setStatsRequirements: CARTA.ISetStatsRequirements[];
+    regionStatsData: CARTA.IRegionStatsData[];
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    openFile:
+        [
+            {
+                directory: testSubdirectory,
+                file: "M17_SWex.fits",
+                fileId: 0,
+                hdu: "0",
+                renderMode: CARTA.RenderMode.RASTER,
+            },
+            {
+                directory: testSubdirectory,
+                file: "M17_SWex.hdf5",
+                fileId: 0,
+                hdu: "0",
+                renderMode: CARTA.RenderMode.RASTER,
+            },
+        ],
+    addRequiredTiles: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.POLYGON,
+                controlPoints: [{ x: 155, y: 552 }, { x: 134, y: 498 }, { x: 185, y: 509 }],
+                rotation: 0.0,
+            },
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.POLYGON,
+                controlPoints: [{ x: 116, y: 604 }, { x: 106, y: 574 }, { x: 137, y: 577 }],
+                rotation: 0.0,
+            }
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.POLYGON,
+                controlPoints: [{ x: 556, y: 167 }, { x: 547, y: 130 }, { x: 577, y: 139 }],
+                rotation: 0.0,
+            }
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.POLYGON,
+                controlPoints: [{ x: 65, y: 688 }, { x: 69, y: 36 }, { x: 602, y: 77 }, { x: 562, y: 735 }],
+                rotation: 0.0,
+            },
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.POLYGON,
+                controlPoints: [{ x: 300.2, y: 300.2 }, { x: 300.2, y: 301.0 }, { x: 300.7, y: 300.2 }],
+                rotation: 0.0,
+            },
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.POLYGON,
+                controlPoints: [{ x: 299.5, y: 300.5 }, { x: 299.5, y: 299.5 }, { x: 300.5, y: 299.5 }, { x: 300.5, y: 300.5 }],
+                rotation: 0.0,
+            },
+        },
+    ],
+    regionAck: [
+        {
+            success: true,
+            regionId: 1,
+        },
+        {
+            success: true,
+            regionId: 2,
+        },
+        {
+            success: true,
+            regionId: 3,
+        },
+        {
+            success: true,
+            regionId: 4,
+        },
+        {
+            success: true,
+            regionId: 5,
+        },
+        {
+            success: true,
+            regionId: 6,
+        },
+    ],
+    setStatsRequirements: [
+        {
+            fileId: 0,
+            regionId: 1,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 2,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 3,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 4,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 5,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 6,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+    ],
+    regionStatsData: [
+        {
+            regionId: 1,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 1265 },
+                { statsType: CARTA.StatsType.Sum, value: 1.2024647 },
+                { statsType: CARTA.StatsType.FluxDensity, value: 0.05524418 },
+                { statsType: CARTA.StatsType.Mean, value: 0.00095056 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00372206 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.00360005 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.01752493 },
+                { statsType: CARTA.StatsType.Min, value: -0.01051447 },
+                { statsType: CARTA.StatsType.Max, value: 0.01217441 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.01217440 },
+            ]
+        },
+        {
+            regionId: 2,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 132 },
+                { statsType: CARTA.StatsType.Sum, value: -0.09657376 },
+                { statsType: CARTA.StatsType.FluxDensity, value: -0.00443684 },
+                { statsType: CARTA.StatsType.Mean, value: -0.00073162 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00945348 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.00946103 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.01179662 },
+                { statsType: CARTA.StatsType.Min, value: -0.01994896 },
+                { statsType: CARTA.StatsType.Max, value: 0.0235076 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.02350760 },
+            ]
+        },
+        {
+            regionId: 3,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 0 },
+                { statsType: CARTA.StatsType.Sum, value: NaN },
+                { statsType: CARTA.StatsType.FluxDensity, value: NaN },
+                { statsType: CARTA.StatsType.Mean, value: NaN },
+                { statsType: CARTA.StatsType.RMS, value: NaN },
+                { statsType: CARTA.StatsType.Sigma, value: NaN },
+                { statsType: CARTA.StatsType.SumSq, value: NaN },
+                { statsType: CARTA.StatsType.Min, value: NaN },
+                { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
+            ]
+        },
+        {
+            regionId: 4,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 216248 },
+                { statsType: CARTA.StatsType.Sum, value: -7.6253559 },
+                { statsType: CARTA.StatsType.FluxDensity, value: -0.35032758 },
+                { statsType: CARTA.StatsType.Mean, value: -3.52620875e-05 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00473442 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.0047343 },
+                { statsType: CARTA.StatsType.SumSq, value: 4.84713562 },
+                { statsType: CARTA.StatsType.Min, value: -0.03958673 },
+                { statsType: CARTA.StatsType.Max, value: 0.04523611 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.04523611 },
+            ]
+        },
+        {
+            regionId: 5,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 0 },
+                { statsType: CARTA.StatsType.Sum, value: NaN },
+                { statsType: CARTA.StatsType.FluxDensity, value: NaN },
+                { statsType: CARTA.StatsType.Mean, value: NaN },
+                { statsType: CARTA.StatsType.RMS, value: NaN },
+                { statsType: CARTA.StatsType.Sigma, value: NaN },
+                { statsType: CARTA.StatsType.SumSq, value: NaN },
+                { statsType: CARTA.StatsType.Min, value: NaN },
+                { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
+            ]
+        },
+        {
+            regionId: 6,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 1 },
+                { statsType: CARTA.StatsType.Sum, value: -0.00115214 },
+                { statsType: CARTA.StatsType.FluxDensity, value: -5.29322955e-05 },
+                { statsType: CARTA.StatsType.Mean, value: -0.00115214 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00115214 },
+                { statsType: CARTA.StatsType.Sigma, value: 0 },
+                { statsType: CARTA.StatsType.SumSq, value: 1.32743435e-06 },
+                { statsType: CARTA.StatsType.Min, value: -0.00115214 },
+                { statsType: CARTA.StatsType.Max, value: -0.00115214 },
+                { statsType: CARTA.StatsType.Extrema, value: -0.00115214 },
+            ]
+        },
+    ],
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("REGION_STATISTICS_POLYGON: Testing statistics with polygon regions", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
+        });
+
+        assertItem.openFile.map(openFile => {
+            describe(`Open image "${openFile.file}" to set image view`, () => {
+                test(`Preparation: Open image`,async () => {
+                    msgController.closeFile(-1);
+                    let OpenFileResponse = await msgController.loadFile(openFile);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                    msgController.addRequiredTiles(assertItem.addRequiredTiles);
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                });
+
+                assertItem.setRegion.map((region, index) => {
+                    if (region.regionId) {
+                        describe(`${region.regionId < 0 ? "Creating" : "Modify"} ${CARTA.RegionType[region.regionInfo.regionType]} region #${assertItem.regionAck[index].regionId} on ${JSON.stringify(region.regionInfo.controlPoints)}`, () => {
+                            let SetRegionAck: any;
+                            test(`SET_REGION_ACK should return within ${regionTimeout} ms`, async () => {
+                                SetRegionAck = await msgController.setRegion(region.fileId, region.regionId, region.regionInfo);
+                            }, regionTimeout);
+    
+                            test(`SET_REGION_ACK.success = ${assertItem.regionAck[index].success}`, () => {
+                                expect(SetRegionAck.success).toBe(assertItem.regionAck[index].success);
+                            });
+    
+                            test(`SET_REGION_ACK.region_id = ${assertItem.regionAck[index].regionId}`, () => {
+                                expect(SetRegionAck.regionId).toEqual(assertItem.regionAck[index].regionId);
+                            });
+    
+                        });
+                    };
+    
+                    describe(`SET STATS REQUIREMENTS on ${CARTA.RegionType[region.regionInfo.regionType]} region #${assertItem.regionAck[index].regionId}`, () => {
+                        let RegionStatsData: any;
+                        test(`REGION_STATS_DATA should return within ${regionTimeout} ms`, async () => {
+                            await msgController.setStatsRequirements(assertItem.setStatsRequirements[index]);
+                            RegionStatsData = await Stream(CARTA.RegionStatsData,1);
+                        }, regionTimeout);
+    
+                        test(`REGION_STATS_DATA.region_id = ${assertItem.regionStatsData[index].regionId}`, () => {
+                            expect(RegionStatsData[0].regionId).toEqual(assertItem.regionStatsData[index].regionId);
+                        });
+    
+                        test("Assert & Check REGION_STATS_DATA.statistics", () => {
+                            assertItem.regionStatsData[index].statistics.map(stats => {
+                                if (isNaN(stats.value)) {
+                                    expect(isNaN(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value)).toBe(true);
+                                } else {
+                                    expect(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value).toBeCloseTo(stats.value, assertItem.precisionDigits);
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/REGION_STATISTICS_RECTANGLE.test.ts
+++ b/src/test/REGION_STATISTICS_RECTANGLE.test.ts
@@ -1,0 +1,390 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let regionTimeout = config.timeout.region;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile[];
+    addRequiredTiles: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setRegion: CARTA.ISetRegion[];
+    regionAck: CARTA.ISetRegionAck[];
+    setStatsRequirements: CARTA.ISetStatsRequirements[];
+    regionStatsData: CARTA.IRegionStatsData[];
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile:
+        [
+            {
+                directory: testSubdirectory,
+                file: "M17_SWex.image",
+                fileId: 0,
+                hdu: "0",
+                renderMode: CARTA.RenderMode.RASTER,
+            },
+            {
+                directory: testSubdirectory,
+                file: "M17_SWex.hdf5",
+                fileId: 0,
+                hdu: "0",
+                renderMode: CARTA.RenderMode.RASTER,
+            },
+        ],
+    addRequiredTiles: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setRegion: [
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "rectangle_1",
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 212, y: 464 }, { x: 10, y: 10 }],
+                rotation: 0.0,
+            },
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "rectangle_2",
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 103, y: 549 }, { x: 5, y: 7 }],
+                rotation: 0.0,
+            },
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "rectangle_3",
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 115, y: 544 }, { x: 5, y: 7 }],
+                rotation: 300.0,
+            }
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                // regionName: "rectangle_4",
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 0, y: 544 }, { x: 5, y: 7 }],
+                rotation: 300.0,
+            }
+        },
+    ],
+    regionAck: [
+        {
+            success: true,
+            regionId: 1,
+        },
+        {
+            success: true,
+            regionId: 2,
+        },
+        {
+            success: true,
+            regionId: 3,
+        },
+        {
+            success: true,
+            regionId: 4,
+        },
+        {
+            success: true,
+            regionId: 5,
+        },
+    ],
+    setStatsRequirements: [
+        {
+            fileId: 0,
+            regionId: 1,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 2,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 3,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 4,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
+            ],
+        },
+    ],
+    regionStatsData: [
+        {
+            regionId: 1,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 121 },
+                { statsType: CARTA.StatsType.Sum, value: 0.28389804 },
+                { statsType: CARTA.StatsType.FluxDensity, value: 0.01304297 },
+                { statsType: CARTA.StatsType.Mean, value: 0.00234626 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00388394 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.00310803 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.00182528 },
+                { statsType: CARTA.StatsType.Min, value: -0.00358113 },
+                { statsType: CARTA.StatsType.Max, value: 0.00793927 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.00793926 },
+            ]
+        },
+        {
+            regionId: 2,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 14 },
+                { statsType: CARTA.StatsType.Sum, value: -0.03493149 },
+                { statsType: CARTA.StatsType.FluxDensity, value: -0.00160484 },
+                { statsType: CARTA.StatsType.Mean, value: -0.00249511 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00586684 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.00551027 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.00048188 },
+                { statsType: CARTA.StatsType.Min, value: -0.0095625 },
+                { statsType: CARTA.StatsType.Max, value: 0.00694707 },
+                { statsType: CARTA.StatsType.Extrema, value: -0.00956249 },
+            ]
+        },
+        {
+            regionId: 3,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 35 },
+                { statsType: CARTA.StatsType.Sum, value: 0.16957074 },
+                { statsType: CARTA.StatsType.FluxDensity, value: 0.0077905 },
+                { statsType: CARTA.StatsType.Mean, value: 0.00484488 },
+                { statsType: CARTA.StatsType.RMS, value: 0.01209958 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.01124911 },
+                { statsType: CARTA.StatsType.SumSq, value: 0.00512399 },
+                { statsType: CARTA.StatsType.Min, value: -0.01768329 },
+                { statsType: CARTA.StatsType.Max, value: 0.02505673 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.02505672 },
+            ]
+        },
+        {
+            regionId: 4,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 0 },
+                { statsType: CARTA.StatsType.Sum, value: NaN },
+                { statsType: CARTA.StatsType.FluxDensity, value: NaN },
+                { statsType: CARTA.StatsType.Mean, value: NaN },
+                { statsType: CARTA.StatsType.RMS, value: NaN },
+                { statsType: CARTA.StatsType.Sigma, value: NaN },
+                { statsType: CARTA.StatsType.SumSq, value: NaN },
+                { statsType: CARTA.StatsType.Min, value: NaN },
+                { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
+            ]
+        },
+        {
+            regionId: -1,
+            statistics: [
+                { statsType: CARTA.StatsType.NumPixels, value: 216248 },
+                { statsType: CARTA.StatsType.Sum, value: -7.6253559 },
+                { statsType: CARTA.StatsType.FluxDensity, value: -0.35032758 },
+                { statsType: CARTA.StatsType.Mean, value: -3.52620875e-05 },
+                { statsType: CARTA.StatsType.RMS, value: 0.00473442 },
+                { statsType: CARTA.StatsType.Sigma, value: 0.0047343 },
+                { statsType: CARTA.StatsType.SumSq, value: 4.84713562 },
+                { statsType: CARTA.StatsType.Min, value: -0.03958673 },
+                { statsType: CARTA.StatsType.Max, value: 0.04523611 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.04523611 },
+            ]
+        },
+    ],
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("REGION_STATISTICS_RECTANGLE: Testing statistics with rectangle regions", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
+        });
+
+        assertItem.openFile.map(openFile => {
+            describe(`Open image "${openFile.file}" to set image view`, () => {
+                test(`Preparation: Open image`,async () => {
+                    msgController.closeFile(-1);
+                    let OpenFileResponse = await msgController.loadFile(openFile);
+                    expect(OpenFileResponse.success).toEqual(true);
+                    let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+
+                    msgController.addRequiredTiles(assertItem.addRequiredTiles);
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData,3);
+                    msgController.setCursor(assertItem.setCursor.fileId, assertItem.setCursor.point.x, assertItem.setCursor.point.y);
+                    let SpatialProfileDataResponse = await Stream(CARTA.SpatialProfileData,1);
+                });
+
+                assertItem.setRegion.map((region, index) => {
+                    if (region.regionId) {
+                        describe(`${region.regionId < 0 ? "Creating" : "Modify"} ${CARTA.RegionType[region.regionInfo.regionType]} region #${assertItem.regionAck[index].regionId} on ${JSON.stringify(region.regionInfo.controlPoints)}`, () => {
+                            let SetRegionAck: any;
+                            test(`SET_REGION_ACK should return within ${regionTimeout} ms`, async () => {
+                                SetRegionAck = await msgController.setRegion(region.fileId, region.regionId, region.regionInfo);
+                                // await Connection.send(CARTA.SetRegion, region);
+                                // SetRegionAck = await Connection.receive(CARTA.SetRegionAck);
+                            }, regionTimeout);
+    
+                            test(`SET_REGION_ACK.success = ${assertItem.regionAck[index].success}`, () => {
+                                expect(SetRegionAck.success).toBe(assertItem.regionAck[index].success);
+                            });
+    
+                            test(`SET_REGION_ACK.region_id = ${assertItem.regionAck[index].regionId}`, () => {
+                                expect(SetRegionAck.regionId).toEqual(assertItem.regionAck[index].regionId);
+                            });
+    
+                        });
+                    };
+    
+                    describe(`SET STATS REQUIREMENTS on ${CARTA.RegionType[region.regionInfo.regionType]} region #${assertItem.regionAck[index].regionId}`, () => {
+                        let RegionStatsData: any;
+                        test(`REGION_STATS_DATA should return within ${regionTimeout} ms`, async () => {
+                            await msgController.setStatsRequirements(assertItem.setStatsRequirements[index]);
+                            RegionStatsData = await Stream(CARTA.RegionStatsData,1);
+                        }, regionTimeout);
+    
+                        test(`REGION_STATS_DATA.region_id = ${assertItem.regionStatsData[index].regionId}`, () => {
+                            expect(RegionStatsData[0].regionId).toEqual(assertItem.regionStatsData[index].regionId);
+                        });
+    
+                        test("Assert & Check REGION_STATS_DATA.statistics", () => {
+                            assertItem.regionStatsData[index].statistics.map(stats => {
+                                if (isNaN(stats.value)) {
+                                    expect(isNaN(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value)).toBe(true);
+                                } else {
+                                    expect(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value).toBeCloseTo(stats.value, assertItem.precisionDigits);
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        describe(`SET STATS REQUIREMENTS on region #-1`, () => {
+            let RegionStatsData: any;
+            test(`REGION_STATS_DATA should return within ${regionTimeout} ms`, async () => {
+                await msgController.setStatsRequirements(assertItem.setStatsRequirements[4]);
+                RegionStatsData = await Stream(CARTA.RegionStatsData,1);
+            }, regionTimeout);
+
+            test(`REGION_STATS_DATA.region_id = ${assertItem.regionStatsData[4].regionId}`, () => {
+                expect(RegionStatsData[0].regionId).toEqual(assertItem.regionStatsData[4].regionId);
+            });
+
+            test("Assert & Check REGION_STATS_DATA.statistics", () => {
+                assertItem.regionStatsData[4].statistics.map(stats => {
+                    if (isNaN(stats.value)) {
+                        expect(isNaN(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value)).toBe(true);
+                    } else {
+                        expect(RegionStatsData[0].statistics.find(f => f.statsType === stats.statsType).value).toBeCloseTo(stats.value, assertItem.precisionDigits);
+                    }
+                });
+            });
+        });
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/RESUME_CATALOG.test.ts
+++ b/src/test/RESUME_CATALOG.test.ts
@@ -1,0 +1,111 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import { take } from 'rxjs/operators';
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let resumeTimeout = config.timeout.resume;
+
+interface AssertItem {
+    precisionDigits: number;
+    resumeSession?: CARTA.IResumeSession;
+    resumeSessionAck?: CARTA.IResumeSessionAck;
+    catalogFilterRequest: CARTA.ICatalogFilterRequest;
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    resumeSession:
+    {
+        images:
+            [
+                {
+                    directory: testSubdirectory,
+                    file: "model.fits",
+                    fileId: 0,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    channel: 0,
+                    stokes: 0,
+                },
+            ],
+        catalogFiles: [
+            {
+                directory: testSubdirectory,
+                name: "test_fk4.xml",
+                fileId: 1,
+                previewDataSize: 10,
+            },
+        ],
+    },
+    resumeSessionAck:
+    {
+        success: true,
+        message: "",
+    },
+    catalogFilterRequest: {
+        fileId: 1,
+        columnIndices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        subsetStartIndex: 0,
+        subsetDataSize: 6,
+    },
+}
+
+let basepath: string;
+describe("RESUME CONTOUR: Test to resume contour lines", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the assertItem.resumeSession.image.directory`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.resumeSession.images[0].directory = basepath + "/" + assertItem.resumeSession.images[0].directory;
+            assertItem.resumeSession.catalogFiles[0].directory = basepath + "/" + assertItem.resumeSession.catalogFiles[0].directory;
+        });
+
+        let RegionHistogramData = [];
+        test(`Resume Image: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
+            msgController.histogramStream.pipe(take(2)).subscribe({
+                next: (data) => {RegionHistogramData.push(data)},
+                complete: () => {
+                    expect(RegionHistogramData.length).toEqual(2)
+                }
+            });
+            let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+            expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            if (ResumeAck.message) {
+                console.warn(`RESUME_SESSION_ACK error message: 
+                        ${ResumeAck.message}`);
+            }
+        }, resumeTimeout);
+
+        describe(`Register another session`, () => {
+            let RegionHistogramData2 = [];
+            test(`Resume Images again: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async ()=> {
+                await msgController.connect(testServerUrl);
+                msgController.histogramStream.pipe(take(2)).subscribe({
+                    next: (data) => {RegionHistogramData2.push(data)},
+                    complete: () => {
+                        expect(RegionHistogramData2.length).toEqual(2)
+                    }
+                });
+                let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+                expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            }, resumeTimeout);
+
+            test(`Assert the CATALOG_FILTER_RESPONSE.columns.length = ${assertItem.catalogFilterRequest.columnIndices.length}`, async () => {
+                msgController.setCatalogFilterRequest(assertItem.catalogFilterRequest);
+                let ack = await Stream(CARTA.CatalogFilterResponse, 1);
+                expect(Object.keys(ack[0].columns).length).toEqual(assertItem.catalogFilterRequest.columnIndices.length);
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/RESUME_CONTOUR.test.ts
+++ b/src/test/RESUME_CONTOUR.test.ts
@@ -1,0 +1,115 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import { take } from 'rxjs/operators';
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let resumeTimeout = config.timeout.resume;
+
+interface AssertItem {
+    precisionDigits: number;
+    resumeSession?: CARTA.IResumeSession;
+    resumeSessionAck?: CARTA.IResumeSessionAck;
+    setImageChannels: CARTA.ISetImageChannels;
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    resumeSession:
+    {
+        images:
+            [
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.fits",
+                    fileId: 0,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    channel: 0,
+                    stokes: 0,
+                    contourSettings: {
+                        fileId: 0,
+                        referenceFileId: 0,
+                        imageBounds: { xMin: 0, xMax: 800, yMin: 0, yMax: 800 },
+                        levels: [
+                            1.5, 2.0, 2.5, 3.0,
+                            3.5, 4.0, 4.5, 5.0,
+                            5.5, 6.0, 6.5, 7.0,
+                        ],
+                        smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+                        smoothingFactor: 4,
+                        decimationFactor: 4,
+                        compressionLevel: 8,
+                        contourChunkSize: 100000,
+                    },
+                },
+            ]
+    },
+    resumeSessionAck:
+    {
+        success: true,
+        message: "",
+    },
+    setImageChannels: {
+        fileId: 0,
+        channel: 1,
+        stokes: 0,
+    },
+}
+
+let basepath: string;
+describe("RESUME CONTOUR: Test to resume contour lines", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the assertItem.resumeSession.image.directory`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.resumeSession.images[0].directory = basepath + "/" + assertItem.resumeSession.images[0].directory;
+        });
+
+        let RegionHistogramData = [];
+        test(`Resume Image: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
+            msgController.histogramStream.pipe(take(2)).subscribe({
+                next: (data) => {RegionHistogramData.push(data)},
+                complete: () => {
+                    expect(RegionHistogramData.length).toEqual(2)
+                }
+            });
+            let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+            expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            if (ResumeAck.message) {
+                console.warn(`RESUME_SESSION_ACK error message: 
+                        ${ResumeAck.message}`);
+            }
+        }, resumeTimeout);
+
+        describe(`Register another session`, () => {
+            let RegionHistogramData2 = [];
+            test(`Resume Images again: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async ()=> {
+                await msgController.connect(testServerUrl);
+                msgController.histogramStream.pipe(take(2)).subscribe({
+                    next: (data) => {RegionHistogramData2.push(data)},
+                    complete: () => {
+                        expect(RegionHistogramData2.length).toEqual(2)
+                    }
+                });
+                let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+                expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            }, resumeTimeout);
+
+            test(`Receive ${assertItem.resumeSession.images[0].contourSettings.levels.length} set of contour lines`, async () => {
+                msgController.setChannels(assertItem.setImageChannels);
+                let ContourImageResponse = await Stream(CARTA.ContourImageData, 12);
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/RESUME_IMAGE.test.ts
+++ b/src/test/RESUME_IMAGE.test.ts
@@ -1,0 +1,123 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import { take } from 'rxjs/operators';
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let resumeTimeout = config.timeout.resume;
+let renderTimeout = config.timeout.renderImages;
+
+interface AssertItem {
+    precisionDigits: number;
+    resumeSession?: CARTA.IResumeSession;
+    resumeSessionAck?: CARTA.IResumeSessionAck;
+    addRequiredTiles?: CARTA.IAddRequiredTiles[];
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    resumeSession:
+    {
+        images:
+            [
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.fits",
+                    fileId: 0,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    channel: 0,
+                    stokes: 0,
+                },
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.image",
+                    fileId: 1,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    channel: 0,
+                    stokes: 0,
+                },
+            ]
+    },
+    resumeSessionAck:
+    {
+        success: true,
+        message: "",
+    },
+    addRequiredTiles: [
+        {
+            fileId: 0,
+            tiles: [0],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+        },
+        {
+            fileId: 1,
+            tiles: [0],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+        },
+    ],
+}
+
+let basepath: string;
+describe("RESUME IMAGE: Test to resume images", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the assertItem.resumeSession.image.directory`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            for (let i = 0; i < 2; i++) {
+                assertItem.resumeSession.images[i].directory = basepath + "/" + assertItem.resumeSession.images[i].directory;
+            }
+        });
+
+        let RegionHistogramData = [];
+        test(`Resume Image: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
+            msgController.histogramStream.pipe(take(2)).subscribe({
+                next: (data) => {RegionHistogramData.push(data)},
+                complete: () => {
+                    expect(RegionHistogramData.length).toEqual(2)
+                }
+            });
+            let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+            expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            if (ResumeAck.message) {
+                console.warn(`RESUME_SESSION_ACK error message: 
+                        ${ResumeAck.message}`);
+            }
+        }, resumeTimeout);
+
+        describe(`Register another session`, () => {
+            let RegionHistogramData2 = [];
+            test(`Resume Images again: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async ()=> {
+                await msgController.connect(testServerUrl);
+                msgController.histogramStream.pipe(take(2)).subscribe({
+                    next: (data) => {RegionHistogramData2.push(data)},
+                    complete: () => {
+                        expect(RegionHistogramData2.length).toEqual(2)
+                    }
+                });
+                let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+                expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            }, resumeTimeout);
+
+            assertItem.resumeSession.images.map((image, index) => {
+                test(`Try to render file ID ${image.fileId}`, async () => {
+                    msgController.addRequiredTiles(assertItem.addRequiredTiles[index]);
+                    let RasterTileDataResponse = await Stream(CARTA.RasterTileData, assertItem.addRequiredTiles[index].tiles.length + 2);
+                }, renderTimeout);
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/RESUME_REGION.test.ts
+++ b/src/test/RESUME_REGION.test.ts
@@ -1,0 +1,148 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import { take } from 'rxjs/operators';
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let resumeTimeout = config.timeout.resume;
+let regionTimeout = config.timeout.region;
+
+interface AssertItem {
+    precisionDigits: number;
+    resumeSession?: CARTA.IResumeSession;
+    resumeSessionAck?: CARTA.IResumeSessionAck;
+    setStatsRequirements: CARTA.ISetStatsRequirements[];
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    resumeSession:
+    {
+        images:
+            [
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.fits",
+                    fileId: 0,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    channel: 0,
+                    stokes: 0,
+                    regions: {
+                        "1": {
+                            regionType: CARTA.RegionType.RECTANGLE,
+                            controlPoints: [{ x: 250, y: 350 }, { x: 80, y: 60 }],
+                            rotation: 0,
+                        },
+                    },
+                },
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.image",
+                    fileId: 1,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    channel: 0,
+                    stokes: 0,
+                    regions: {
+                        "2": {
+                            regionType: CARTA.RegionType.RECTANGLE,
+                            controlPoints: [{ x: 350, y: 250 }, { x: 60, y: 80 }],
+                            rotation: 0,
+                        },
+                    },
+                },
+            ]
+    },
+    resumeSessionAck:
+    {
+        success: true,
+        message: "",
+    },
+    setStatsRequirements: [
+        {
+            fileId: 0,
+            regionId: 1,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.NanCount,
+                    CARTA.StatsType.Sum,
+                ]}
+            ],
+        },
+        {
+            fileId: 1,
+            regionId: 2,
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.NanCount,
+                    CARTA.StatsType.Sum,
+                ]}
+            ],
+        },
+    ],
+}
+
+let basepath: string;
+describe("RESUME REGION: Test to resume regions", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the assertItem.resumeSession.image.directory`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            for (let i = 0; i < 2; i++) {
+                assertItem.resumeSession.images[i].directory = basepath + "/" + assertItem.resumeSession.images[i].directory;
+            }
+        });
+
+        let RegionHistogramData = [];
+        test(`Resume Image: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
+            msgController.histogramStream.pipe(take(2)).subscribe({
+                next: (data) => {RegionHistogramData.push(data)},
+                complete: () => {
+                    expect(RegionHistogramData.length).toEqual(2)
+                }
+            });
+            let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+            expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            if (ResumeAck.message) {
+                console.warn(`RESUME_SESSION_ACK error message: 
+                        ${ResumeAck.message}`);
+            }
+        }, resumeTimeout);
+
+        describe(`Register another session`, () => {
+            let RegionHistogramData2 = [];
+            test(`Resume Images again: 2 REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async ()=> {
+                await msgController.connect(testServerUrl);
+                msgController.histogramStream.pipe(take(2)).subscribe({
+                    next: (data) => {RegionHistogramData2.push(data)},
+                    complete: () => {
+                        expect(RegionHistogramData2.length).toEqual(2)
+                    }
+                });
+                let ResumeAck = await msgController.resumeSession(assertItem.resumeSession);
+                expect(ResumeAck.success).toBe(assertItem.resumeSessionAck.success);
+            }, resumeTimeout);
+
+
+            assertItem.setStatsRequirements.map(stats => {
+                test(`Try to request stats of region ${stats.regionId}`, async () => {
+                    msgController.setStatsRequirements(stats);
+                    let RegionStatsDataResponse = await Stream(CARTA.RegionStatsData, 1);
+                }, regionTimeout);
+            });
+        })
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/TILE_DATA_REQUEST.test.ts
+++ b/src/test/TILE_DATA_REQUEST.test.ts
@@ -1,0 +1,203 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+
+interface IRasterTileDataExt extends CARTA.IRasterTileData {
+    assert: {
+        lengthTiles: number,
+    }[];
+}
+interface AssertItem {
+    precisionDigit: number;
+    fileOpen: CARTA.IOpenFile;
+    fileOpenAck: CARTA.IOpenFileAck;
+    initTilesReq: CARTA.IAddRequiredTiles;
+    initSetCursor: CARTA.ISetCursor;
+    initSpatialReq: CARTA.ISetSpatialRequirements;
+    rasterTileData: IRasterTileDataExt;
+    addRequiredTilesGroup: CARTA.IAddRequiredTiles[];
+    rasterTileDataGroup: IRasterTileDataExt[];
+}
+let assertItem: AssertItem = {
+    precisionDigit: 4,
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "cluster_04096.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    fileOpenAck: {
+        success: true,
+        fileFeatureFlags: 0,
+    },
+    initTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.NONE,
+        tiles: [16777216, 16781312, 16777217, 16781313],
+    },
+    initSetCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    initSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: [{coordinate:"x"}, {coordinate:"y"}]
+    },
+    rasterTileData: {
+        fileId: 0,
+        channel: 0,
+        stokes: 0,
+        compressionType: CARTA.CompressionType.NONE,
+        compressionQuality: 11,
+        tiles: [
+            { x: 0, y: 0, layer: 1, },
+            { x: 1, y: 0, layer: 1, },
+            { x: 0, y: 1, layer: 1, },
+            { x: 1, y: 1, layer: 1, },
+        ],
+        assert: [
+            { lengthTiles: 1, },
+            { lengthTiles: 1, },
+            { lengthTiles: 1, },
+            { lengthTiles: 1, },
+        ],
+    },
+    addRequiredTilesGroup: [
+        {
+            fileId: 0,
+            tiles: [33558529, 33562626, 33566723],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+        },
+        {
+            fileId: 0,
+            tiles: [33558529, 33562626, 33566723, 33570820],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+            // Jest only received one returned message from Backend {RasterTileSync: [RasterTileSync {}]} as Stream
+            // No RASTER_TILE_DATA returned
+            // BackendLog:
+            // Mean filter 0x0 raster data to 0x0 in 0.003 ms at 0 MPix/s
+            // Bus error(core dumped)
+            // or BackendLog:
+            // Mean filter 0x0 raster data to 0x0 in 0.002 ms at 0 MPix/s
+            // Segmentation fault(core dumped)
+        },
+        // {
+        //     fileId: 0,
+        //     tiles: [33570820],
+        //     compressionType: CARTA.CompressionType.ZFP,
+        //     compressionQuality: 11,
+        //     // BackendLog:
+        //     // Mean filter 0x0 raster data to 0x0 in 0.01 ms at 0 MPix / s 
+        //     // Segmentation fault(core dumped)
+        // },
+        // {
+        //     fileId: 0,
+        //     tiles: [50364424],
+        //     compressionType: CARTA.CompressionType.ZFP,
+        //     compressionQuality: 11,
+        //     // BackendLog:
+        //     // Mean filter 0x0 raster data to 0x0 in 0.012 ms at 0 MPix / s 
+        //     // Segmentation fault(core dumped)
+        //     // or BackendLog:
+        //     // Mean filter 0x0 raster data to 0x0 in 0.002 ms at 0 MPix / s 
+        //     // Bus error(core dumped)
+        // },
+    ],
+    rasterTileDataGroup: [
+        {
+            tiles: [
+                { x: 1, y: 1, layer: 2, },
+                { x: 2, y: 2, layer: 2, },
+                { x: 3, y: 3, layer: 2, },
+            ],
+            assert: [
+                { lengthTiles: 1, },
+                { lengthTiles: 1, },
+                { lengthTiles: 1, },
+            ],
+        },
+        {
+            tiles: [
+                { x: 1, y: 1, layer: 2, },
+                { x: 2, y: 2, layer: 2, },
+                { x: 3, y: 3, layer: 2, },
+            ],
+            assert: [
+                { lengthTiles: 1, },
+                { lengthTiles: 1, },
+                { lengthTiles: 1, },
+            ],
+        },
+        // {
+        //     tiles: [],
+        //     assert: [],
+        // },
+        // {
+        //     tiles: [],
+        //     assert: [],
+        // },
+    ],
+};
+
+let basepath: string;
+describe("CHECK_RASTER_TILE_DATA: Testing data values at different layers in RASTER_TILE_DATA", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.fileOpen.directory = basepath + "/" + assertItem.fileOpen.directory;
+        });
+
+        test(`Preparation: Open image`,async () => {
+            msgController.closeFile(-1);
+            let OpenFileResponse = await msgController.loadFile(assertItem.fileOpen);
+            expect(OpenFileResponse.success).toEqual(true);
+            let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+        });
+
+        let RasterTileDataResponse: CARTA.RasterTileData;
+        test(`RasterTileData * 4 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)?`, async () => {
+            await msgController.addRequiredTiles(assertItem.initTilesReq);
+            RasterTileDataResponse = await Stream(CARTA.RasterTileData,assertItem.initTilesReq.tiles.length + 2);
+
+            await msgController.setCursor(assertItem.initSetCursor.fileId, assertItem.initSetCursor.point.x, assertItem.initSetCursor.point.y);
+            let SpatialProfileDataResponse1 = await Stream(CARTA.SpatialProfileData,1);
+
+            await msgController.setSpatialRequirements(assertItem.initSpatialReq);
+            let SpatialProfileDataResponse2 = await Stream(CARTA.SpatialProfileData,1);
+        }, readFileTimeout);
+
+        assertItem.rasterTileData.tiles.map((tiles, index) => {
+            describe(`(Step1-3) Check each RASTER_TILE_DATA`, () => {
+                test(`(#${index})RASTER_TILE_DATA.tiles.length = 1 |`, () => {
+                    expect(RasterTileDataResponse[index+1].tiles.length).toEqual(assertItem.rasterTileData.assert[index].lengthTiles)
+                });
+
+                test(`(#${index})RASTER_TILE_DATA.tiles[0].x = ${tiles.x} & RASTER_TILE_DATA.tiles[0].y = ${tiles.y} & RASTER_TILE_DATA.tiles[0].layer = ${tiles.layer}|`, () => {
+                    let TempTiles = assertItem.rasterTileData.tiles.filter(f => f.x === RasterTileDataResponse[index+1].tiles[0].x && f.y === RasterTileDataResponse[index+1].tiles[0].y && f.layer === RasterTileDataResponse[index+1].tiles[0].layer);
+                    expect(TempTiles).toBeDefined();
+                })
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+})

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -1,5 +1,4 @@
 {
-    "serverURL": "wss://carta.asiaa.sinica.edu.tw/socketdev",
     "serverURL0": "ws://127.0.0.1:3002",	
     "path": {
         "root": ".",

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -33,7 +33,7 @@
         "messageEvent": 500,
         "mouseEvent": 1000,
         "cursor": 500,
-        "region": 500,
+        "region": 5000,
         "import": 500,
         "export": 500,
         "resume": 3000,

--- a/src/test/myClient.ts
+++ b/src/test/myClient.ts
@@ -118,6 +118,17 @@ function Stream(cartaType: any, InputNum?: number) {
                     }
                 })
                 break;
+            case CARTA.CatalogFilterResponse:
+                let catalogStream : any [] = [];
+                let resCatalogStream = msgController.catalogStream.pipe(take(InputNum));
+                resCatalogStream.subscribe(data => {
+                    catalogStream.push(data);
+                    _count++;
+                    if (_count === InputNum) {
+                        resolve(catalogStream);
+                    }
+                })
+                break;
         }
     })
 }


### PR DESCRIPTION
Could you test the part 1 of RxJS ICD tests?
They are default connecting to the local carta-backend. e.g. `"serverURL0": "ws://127.0.0.1:3002"`
I am afraid of the server may have a different path to my local computer, then it may cause the failure.
please test them on the server and let me know whether there is any problem I can fix!

