### PR TITLE
Mylin/vector overlay tests

### DIFF
--- a/src/test/VECTOR_OVERLAY_CASA.test.ts
+++ b/src/test/VECTOR_OVERLAY_CASA.test.ts
@@ -35,7 +35,7 @@ let assertItem: AssertItem = {
     filelist: { directory: testSubdirectory },
     openFile: {
         directory: testSubdirectory,
-        file: "HH211_IQU.fits",
+        file: "HH211_IQU.image",
         hdu: "",
         fileId: 0,
         renderMode: CARTA.RenderMode.RASTER,
@@ -334,7 +334,7 @@ function sleep(ms) {
 }
 
 let basepath: string;
-describe("VECTOR_OVERLAY_FITS: Testing the vector overlay ICD messages with the polarization fits image", () => {
+describe("VECTOR_OVERLAY_CASA: Testing the vector overlay ICD messages with the polarization casa image", () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async ()=> {

--- a/src/test/VECTOR_OVERLAY_CHANNEL_STREAM.test.ts
+++ b/src/test/VECTOR_OVERLAY_CHANNEL_STREAM.test.ts
@@ -1,0 +1,257 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+import { take } from 'rxjs/operators';
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let openFileTimeout: number = config.timeout.openFile;
+let connectTimeout: number = config.timeout.connection;
+let vectorOverlayTimeout: number = config.timeout.vectorOverlay;
+
+interface IVectorOverlayTileDataExt extends CARTA.IVectorOverlayTileData {
+    totalAngleImageDataLength?: Number;
+    totalIntensityImageDataLength?: Number;
+    selectedAngleImageDataIndex?: Number[];
+    selectedAngleImageDataValue?: Number[];
+    selectedIntensityImageDataIndex?: Number[];
+    selectedIntensityImageDataValue?: Number[];
+}
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setVectorOverlayParameters: CARTA.ISetVectorOverlayParameters[];
+    VectorOverlayTileData : IVectorOverlayTileDataExt[];
+    setImageChannel: CARTA.ISetImageChannels[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HH211_IQU.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setVectorOverlayParameters: [
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: true,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: 0.01,
+            uError: undefined
+        },
+    ],
+    VectorOverlayTileData: [
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                mip: 4,
+                layer: 1,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        }, 
+    ],
+    setImageChannel: [
+        {
+            fileId: 0,
+            channel: 1,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50339844, 50348033, 50335748, 50348035, 50343940, 50348032, 50331652, 50348036],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+    ],
+};
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms)).then(() => {});
+}
+
+let basepath: string;
+describe("VECTOR_OVERLAY_CHANNEL_STREAM: Testing the vector overlay ICD messages with the channel stream", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Initialization: open the image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async() => {
+                msgController.closeFile(-1);
+                msgController.closeFile(0);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            }, openFileTimeout);
+
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                msgController.addRequiredTiles(assertItem.addTilesReq);
+                let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                expect(JSON.stringify(RasterTileData[2])).toMatch(/{\"endSync\":true}/)
+            }, openFileTimeout);
+        });
+
+        describe(`Vector Overlay ICD messages with set channel ICD messages:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[0]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[0].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[0].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[0].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[0].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            let VectorOverlayTileDataArrayChannel1 = [];
+            let VectorOverlayTileDataResponseChannel1: any;
+            let RegionHistogramData: any;
+            test(`(Step 4) Set Image Channel to 1 and Receive the three type ICD messages:`, async ()=> {
+                msgController.setChannels(assertItem.setImageChannel[0]);
+                let VectorOverlayTileDataPromiseChannel1 = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArrayChannel1.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArrayChannel1)
+                            }
+                        }
+                    });
+                });
+
+                let RasterTileData = [];
+                let RasterTileDataSync = [];
+
+                let RasterTileDataSyncPromise = new Promise((resolve) => {
+                    msgController.rasterSyncStream.subscribe({
+                        next: (data) => {
+                            RasterTileDataSync.push(data)
+                            if (data.endSync === true) {
+                                resolve(RasterTileDataSync)
+                            }
+                        }
+                    })
+                })
+
+                let RasterTileDataPromise = new Promise((resolve) => {
+                    msgController.rasterTileStream.subscribe({
+                        next: (data) => {
+                            RasterTileData.push(data)
+                            if (RasterTileData.length === assertItem.setImageChannel[0].requiredTiles.tiles.length) {
+                                resolve(RasterTileData)
+                            }
+                        },
+                    })
+                });
+
+                VectorOverlayTileDataResponseChannel1 = await VectorOverlayTileDataPromiseChannel1;
+                RegionHistogramData = await Stream(CARTA.RegionHistogramData, 1);
+        
+                let RasterTileDataChannel1: any = await RasterTileDataPromise;
+                let RasterTileDataSyncChannel1 = await RasterTileDataSyncPromise;
+                console.log(RasterTileDataChannel1.length);
+                console.log(RasterTileDataSyncChannel1);
+            });
+
+            // test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+            //     msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+            //     let receiveNumberCurrent = msgController.messageReceiving();
+            //     setTimeout(() => {
+            //         let receiveNumberLatter = msgController.messageReceiving();
+            //         expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+            //         done();
+            //     }, 500)
+            // });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/VECTOR_OVERLAY_CHANNEL_STREAM.test.ts
+++ b/src/test/VECTOR_OVERLAY_CHANNEL_STREAM.test.ts
@@ -2,7 +2,6 @@ import { CARTA } from "carta-protobuf";
 import { checkConnection, Stream} from './myClient';
 import { MessageController } from "./MessageController";
 import config from "./config.json";
-import { take } from 'rxjs/operators';
 
 let testServerUrl: string = config.serverURL0;
 let testSubdirectory: string = config.path.QA;
@@ -157,10 +156,6 @@ let assertItem: AssertItem = {
     },
     precisionDigits: 4,
 };
-
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms)).then(() => {});
-}
 
 let basepath: string;
 describe("VECTOR_OVERLAY_CHANNEL_STREAM: Testing the vector overlay ICD messages with the channel stream", () => {
@@ -321,26 +316,22 @@ describe("VECTOR_OVERLAY_CHANNEL_STREAM: Testing the vector overlay ICD messages
                 });
             })
 
-            test(`(Step 5) Verify the Response (REGION_HISTOGRAM_DATA and RASTER_TILE) correctness`, () => {
+            test(`(Step 5) Verify the Response (REGION_HISTOGRAM_DATA, RASTER_TILE, and RASTER_TILE_SYNC) correctness`, () => {
                 expect(RegionHistogramData[0].channel).toEqual(assertItem.regionHistogramData.channel);
                 expect(RegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
                 expect(RegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
                 expect(RegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.regionHistogramData.histograms.mean, assertItem.precisionDigits);
                 expect(RegionHistogramData[0].histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
 
-                console.log(RasterTileDataChannel1.length);
-                console.log(RasterTileDataSyncChannel1);
+                RasterTileDataChannel1.map((data) => {
+                    expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
+                });
+                expect(RasterTileDataChannel1.length).toEqual(assertItem.setImageChannel[0].requiredTiles.tiles.length);
+                RasterTileDataSyncChannel1.map((data) => {
+                    expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
+                })
+                expect(RasterTileDataSyncChannel1[1].endSync).toEqual(true);
             });
-
-            // test(`(Step 3) Clear Vector Overlay ICD`, done =>{
-            //     msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
-            //     let receiveNumberCurrent = msgController.messageReceiving();
-            //     setTimeout(() => {
-            //         let receiveNumberLatter = msgController.messageReceiving();
-            //         expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
-            //         done();
-            //     }, 500)
-            // });
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
+++ b/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
@@ -1,0 +1,353 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let openFileTimeout: number = config.timeout.openFile;
+let connectTimeout: number = config.timeout.connection;
+let vectorOverlayTimeout: number = config.timeout.vectorOverlay;
+
+interface IVectorOverlayTileDataExt extends CARTA.IVectorOverlayTileData {
+    totalAngleImageDataLength?: Number;
+    totalIntensityImageDataLength?: Number;
+    selectedAngleImageDataIndex?: Number[];
+    selectedAngleImageDataValue?: Number[];
+    selectedIntensityImageDataIndex?: Number[];
+    selectedIntensityImageDataValue?: Number[];
+}
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    selectBinIndex?: Number[];
+    selectBinValue?: Number[];
+}
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setVectorOverlayParameters: CARTA.ISetVectorOverlayParameters[];
+    VectorOverlayTileData : IVectorOverlayTileDataExt[];
+    setImageChannel: CARTA.ISetImageChannels[];
+    regionHistogramData: IRegionHistogramDataExt;
+    setContour: CARTA.ISetContourParameters[];
+    precisionDigits: number;
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HH211_IQU.image",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setVectorOverlayParameters: [
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: true,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 1,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: NaN,
+            uError: undefined
+        },
+    ],
+    VectorOverlayTileData: [
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 2500,
+            angleTiles: [{
+                height: 25,
+                mip: 1,
+                layer: 3,
+                width: 25,
+                x: 4,
+                y: 4
+            }],
+            totalIntensityImageDataLength: 2500,
+            intensityTiles: [{
+                height: 25,
+                layer: 3,
+                mip: 1,
+                width: 25,
+                x: 4,
+                y: 4
+            }],
+            selectedAngleImageDataIndex: [3,501, 1002,1500, 2000, 2499],
+            selectedAngleImageDataValue: [127, 0, 192, 0, 0, 127],
+            selectedIntensityImageDataIndex: [3,501, 1002,1500, 2000, 2499],
+            selectedIntensityImageDataValue: [127, 0, 192, 0, 0, 127],
+        }, 
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            channel: 1,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                mip: 4,
+                layer: 1,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        }, 
+    ],
+    setImageChannel: [
+        {
+            fileId: 0,
+            channel: 1,
+            stokes: 0,
+            requiredTiles: {
+                fileId: 0,
+                tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50339844, 50348033, 50335748, 50348035, 50343940, 50348032, 50331652, 50348036],
+                compressionType: CARTA.CompressionType.ZFP,
+                compressionQuality: 11,
+            },
+        },
+    ],
+    regionHistogramData: {
+        channel:1,
+        histograms: {
+            binWidth: 0.0000605975255894009,
+            firstBinCenter: -0.027060849592089653,
+            mean: 0.000027204052476844467,
+            numBins: 1049,
+            stdDev: 0.0028536340154345988
+        },
+        selectBinIndex:[0, 100, 500, 700, 1000],
+        selectBinValue:[0, 100, 500, 700, 1000],
+    },
+    setContour: [
+        {
+            fileId: 0,
+            referenceFileId: 0,
+            imageBounds: {xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            levels: [0.014208443731897273, 0.028416887463794546, 0.042625331195691826, 0.05683377492758909, 0.07104221865948637],
+            smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+            smoothingFactor: 4,
+            decimationFactor: 4,
+            compressionLevel: 8,
+            contourChunkSize: 100000,
+        }
+    ],
+    precisionDigits: 4,
+};
+
+let basepath: string;
+describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD messages with the contours and changing the channel", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Initialization: open the image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async() => {
+                msgController.closeFile(-1);
+                msgController.closeFile(0);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            }, openFileTimeout);
+
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                msgController.addRequiredTiles(assertItem.addTilesReq);
+                let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                expect(JSON.stringify(RasterTileData[2])).toMatch(/{\"endSync\":true}/)
+            }, openFileTimeout);
+        });
+
+        describe(`(Case 1) Set vector overlay and contours:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[0]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[0].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[0].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[0].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[0].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            // let VectorOverlayTileDataArrayChannel1 = [];
+            // let VectorOverlayTileDataResponseChannel1: any;
+            // let RegionHistogramData: any;
+            // let RasterTileDataChannel1: any;
+            // let RasterTileDataSyncChannel1: any;
+            // test(`(Step 3) Set Image Channel to 1 and Receive the three type ICD messages:`, async ()=> {
+            //     msgController.setChannels(assertItem.setImageChannel[0]);
+            //     let VectorOverlayTileDataPromiseChannel1 = new Promise((resolve)=>{
+            //         msgController.vectorTileStream.subscribe({
+            //             next: (data) => {
+            //                 VectorOverlayTileDataArrayChannel1.push(data)
+            //                 if (data.progress === 1) {
+            //                     resolve(VectorOverlayTileDataArrayChannel1)
+            //                 }
+            //             }
+            //         });
+            //     });
+
+            //     let RasterTileData = [];
+            //     let RasterTileDataSync = [];
+
+            //     let RasterTileDataSyncPromise = new Promise((resolve) => {
+            //         msgController.rasterSyncStream.subscribe({
+            //             next: (data) => {
+            //                 RasterTileDataSync.push(data)
+            //                 if (data.endSync === true) {
+            //                     resolve(RasterTileDataSync)
+            //                 }
+            //             }
+            //         })
+            //     })
+
+            //     let RasterTileDataPromise = new Promise((resolve) => {
+            //         msgController.rasterTileStream.subscribe({
+            //             next: (data) => {
+            //                 RasterTileData.push(data)
+            //                 if (RasterTileData.length === assertItem.setImageChannel[0].requiredTiles.tiles.length) {
+            //                     resolve(RasterTileData)
+            //                 }
+            //             },
+            //         })
+            //     });
+
+            //     VectorOverlayTileDataResponseChannel1 = await VectorOverlayTileDataPromiseChannel1;
+            //     RegionHistogramData = await Stream(CARTA.RegionHistogramData, 1);
+        
+            //     RasterTileDataChannel1 = await RasterTileDataPromise;
+            //     RasterTileDataSyncChannel1 = await RasterTileDataSyncPromise;
+            //     // console.log(RasterTileDataChannel1.length);
+            //     // console.log(RasterTileDataSyncChannel1);
+            // });
+
+            // test(`(Step 4: Verify the Response (the last VECTOR_OVERLAY_TILE_DATA of channel 1) correctness)`, () => {
+            //     let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponseChannel1.slice(-1)[0];
+            //     expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[1].progress);
+            //     expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[1].stokesAngle);
+            //     expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[1].stokesIntensity);
+            //     expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[1].compressionQuality);
+            //     expect(lastVectorOverlayTileDataResponse.channel).toEqual(assertItem.VectorOverlayTileData[1].channel);
+
+            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].height);
+            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].mip);
+            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].layer);
+            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].width);
+            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].x);
+            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalAngleImageDataLength);
+            //     assertItem.VectorOverlayTileData[0].selectedAngleImageDataIndex.map((data, index) => {
+            //         expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedAngleImageDataValue[index])
+            //     });
+
+            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].height);
+            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].layer);
+            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].mip);
+            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].width);
+            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].x);
+            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalIntensityImageDataLength);
+            //     assertItem.VectorOverlayTileData[0].selectedIntensityImageDataIndex.map((data, index) => {
+            //         expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedIntensityImageDataValue[index])
+            //     });
+            // })
+
+            // test(`(Step 5) Verify the Response (REGION_HISTOGRAM_DATA, RASTER_TILE, and RASTER_TILE_SYNC) correctness`, () => {
+            //     expect(RegionHistogramData[0].channel).toEqual(assertItem.regionHistogramData.channel);
+            //     expect(RegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+            //     expect(RegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+            //     expect(RegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.regionHistogramData.histograms.mean, assertItem.precisionDigits);
+            //     expect(RegionHistogramData[0].histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+
+            //     RasterTileDataChannel1.map((data) => {
+            //         expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
+            //     });
+            //     expect(RasterTileDataChannel1.length).toEqual(assertItem.setImageChannel[0].requiredTiles.tiles.length);
+            //     RasterTileDataSyncChannel1.map((data) => {
+            //         expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
+            //     })
+            //     expect(RasterTileDataSyncChannel1[1].endSync).toEqual(true);
+            // });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
+++ b/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
@@ -18,11 +18,6 @@ interface IVectorOverlayTileDataExt extends CARTA.IVectorOverlayTileData {
     selectedIntensityImageDataValue?: Number[];
 }
 
-interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
-    selectBinIndex?: Number[];
-    selectBinValue?: Number[];
-}
-
 interface IContourImageDataExt extends CARTA.IContourImageData {
     totalCoordinate?: Number;
     selectedCoordinateIndex?: Number[];
@@ -35,14 +30,15 @@ interface IContourImageDataExt extends CARTA.IContourImageData {
 interface AssertItem {
     registerViewer: CARTA.IRegisterViewer;
     filelist: CARTA.IFileListRequest;
-    openFile: CARTA.IOpenFile;
-    addTilesReq: CARTA.IAddRequiredTiles;
+    openFile: CARTA.IOpenFile[];
+    addTilesReq: CARTA.IAddRequiredTiles[];
     setVectorOverlayParameters: CARTA.ISetVectorOverlayParameters[];
     VectorOverlayTileData : IVectorOverlayTileDataExt[];
     setImageChannel: CARTA.ISetImageChannels[];
-    regionHistogramData: IRegionHistogramDataExt;
+    regionHistogramData: CARTA.IRegionHistogramData[];
     setContour: CARTA.ISetContourParameters[];
-    contourImageData: IContourImageDataExt[]
+    contourImageData: IContourImageDataExt[];
+    contourImageData2: IContourImageDataExt[];
     precisionDigits: number;
 };
 
@@ -52,19 +48,36 @@ let assertItem: AssertItem = {
         clientFeatureFlags: 5,
     },
     filelist: { directory: testSubdirectory },
-    openFile: {
-        directory: testSubdirectory,
-        file: "HH211_IQU.image",
-        hdu: "0",
-        fileId: 0,
-        renderMode: CARTA.RenderMode.RASTER,
-    },
-    addTilesReq: {
-        fileId: 0,
-        compressionQuality: 11,
-        compressionType: CARTA.CompressionType.ZFP,
-        tiles: [0],
-    },
+    openFile: [
+        {
+            directory: testSubdirectory,
+            file: "HH211_IQU.image",
+            hdu: "0",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "HH211_IQU.hdf5",
+            hdu: "",
+            fileId: 1,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+        {
+            fileId: 1,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [0],
+        },
+    ],
     setVectorOverlayParameters: [
         {
             compressionQuality: 8,
@@ -84,6 +97,20 @@ let assertItem: AssertItem = {
             fileId: 0,
             stokesAngle: -1,
             stokesIntensity: -1
+        },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 1,
+            fractional: true,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: 0.01,
+            uError: undefined
         },
     ],
     VectorOverlayTileData: [
@@ -117,6 +144,7 @@ let assertItem: AssertItem = {
         }, 
         {
             progress: 1, 
+            fileId: 1,
             stokesAngle: 1,
             stokesIntensity: 1,
             compressionQuality: 8,
@@ -144,32 +172,87 @@ let assertItem: AssertItem = {
             selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
             selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
         }, 
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            channel: 1,
+            fileId: 1,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                mip: 4,
+                layer: 1,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        }, 
     ],
     setImageChannel: [
         {
-            fileId: 0,
+            fileId: 1,
             channel: 1,
             stokes: 0,
             requiredTiles: {
-                fileId: 0,
+                fileId: 1,
                 tiles: [50339842, 50339841, 50335746, 50335745, 50343938, 50339843, 50343937, 50335747, 50339840, 50331650, 50335744, 50331649, 50343939, 50343936, 50331651, 50331648, 50348034, 50339844, 50348033, 50335748, 50348035, 50343940, 50348032, 50331652, 50348036],
                 compressionType: CARTA.CompressionType.ZFP,
                 compressionQuality: 11,
             },
         },
     ],
-    regionHistogramData: {
-        channel:1,
-        histograms: {
-            binWidth: 0.0000605975255894009,
-            firstBinCenter: -0.027060849592089653,
-            mean: 0.000027204052476844467,
-            numBins: 1049,
-            stdDev: 0.0028536340154345988
+    regionHistogramData: [
+        {
+            channel:1,
+            histograms: {
+                binWidth: 0.0000605975255894009,
+                firstBinCenter: -0.027060849592089653,
+                mean: 0.000027204052476844467,
+                numBins: 1049,
+                stdDev: 0.0028536340154345988
+            },
         },
-        selectBinIndex:[0, 100, 500, 700, 1000],
-        selectBinValue:[0, 100, 500, 700, 1000],
-    },
+        {
+            fileId: 1,
+            histograms: {
+                binWidth: 0.0002482116605919582,
+                firstBinCenter: -0.12420587090720325,
+                mean: 0.000008067378262600356,
+                numBins: 1049,
+                stdDev: 0.014456610096577697
+            },
+            progress: 1,
+            regionId: -1,
+        },
+        {
+            fileId: 1,
+            histograms: {
+                binWidth: 0.00006059752519751186,
+                firstBinCenter: -0.027060850478133436,
+                mean: 0.00002720431488691676,
+                numBins: 1049,
+                stdDev: 0.002852936706926054
+            },
+            progress: 1,
+            regionId: -1,
+            channel: 1,
+        },
+    ],
     setContour: [
         {
             fileId: 0,
@@ -185,7 +268,18 @@ let assertItem: AssertItem = {
         {
             fileId: 0,
             referenceFileId: 0,
-        }
+        },
+        {
+            fileId: 1,
+            referenceFileId: 0,
+            imageBounds: {xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            levels: [0.014208443731897273, 0.042625331195691826, 0.07104221865948637],
+            smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+            smoothingFactor: 4,
+            decimationFactor: 4,
+            compressionLevel: 8,
+            contourChunkSize: 100000,
+        },
     ],
     contourImageData: [
         {
@@ -231,7 +325,45 @@ let assertItem: AssertItem = {
             selectedStartIndicesValue: [0, 174, 32, 36,  108, 196, 220]
         },
     ],
-    precisionDigits: 4,
+    contourImageData2: [
+        {
+            contourSets: [{
+                decimationFactor: 0,
+                level: 0.07104221865948637,
+                uncompressedCoordinatesSize: 0
+            }],
+            fileId: 1,
+            progress: 1,
+            channel: 1,
+        },
+        {
+            contourSets: [{
+                decimationFactor: 0,
+                level: 0.0426253311956918267,
+                uncompressedCoordinatesSize: 0
+            }],
+            fileId: 1,
+            progress: 1,
+            channel: 1,
+        },
+        {
+            contourSets: [{
+                decimationFactor: 4,
+                level: 0.014208443731897273,
+                uncompressedCoordinatesSize: 2144
+            }],
+            fileId: 1,
+            progress: 1,
+            channel: 1,
+            totalCoordinate: 503,
+            selectedCoordinateIndex: [0, 50, 100, 200, 300, 400, 500],
+            selectedCoordinateValue: [40, 42, 41, 235, 131, 11, 114],
+            totalStartIndices: 64,
+            selectedStartIndicesIndex: [0, 10, 20, 30, 40, 50, 60],
+            selectedStartIndicesValue: [0, 0, 142, 0, 44, 0, 6]
+        },
+    ],
+    precisionDigits: 8,
 };
 
 let basepath: string;
@@ -246,20 +378,21 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
         test(`Get basepath and modify the directory path`, async () => {
             let fileListResponse = await msgController.getFileList("$BASE",0);
             basepath = fileListResponse.directory;
-            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+            assertItem.openFile[0].directory = basepath + "/" + assertItem.openFile[0].directory;
+            assertItem.openFile[1].directory = basepath + "/" + assertItem.openFile[1].directory;
         });
 
-        describe(`Initialization: open the image`, () => {
+        describe(`(Case 1) Initialization: open the image`, () => {
             test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async() => {
                 msgController.closeFile(-1);
                 msgController.closeFile(0);
-                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile[0]);
                 expect(OpenFileResponse.success).toEqual(true);
                 let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
             }, openFileTimeout);
 
             test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
-                msgController.addRequiredTiles(assertItem.addTilesReq);
+                msgController.addRequiredTiles(assertItem.addTilesReq[0]);
                 let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
                 expect(JSON.stringify(RasterTileData[2])).toMatch(/{\"endSync\":true}/)
             }, openFileTimeout);
@@ -268,7 +401,7 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
         describe(`(Case 1) Set vector overlay and contours:`, ()=>{
             let VectorOverlayTileDataArray = [];
             let VectorOverlayTileDataResponse: any;
-            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+            test(`(Step 1) Request Vector Overlay and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
                 msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[0]);
                 let VectorOverlayTileDataPromise = new Promise((resolve)=>{
                     msgController.vectorTileStream.subscribe({
@@ -336,108 +469,218 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
                 let receiveNumberCurrent = msgController.messageReceiving();
                 setTimeout(() => {
                     let receiveNumberLatter = msgController.messageReceiving();
-                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 500 ms
                     done();
                 }, 500)
             });
+        });
 
-            // let VectorOverlayTileDataArrayChannel1 = [];
-            // let VectorOverlayTileDataResponseChannel1: any;
-            // let RegionHistogramData: any;
-            // let RasterTileDataChannel1: any;
-            // let RasterTileDataSyncChannel1: any;
-            // test(`(Step 3) Set Image Channel to 1 and Receive the three type ICD messages:`, async ()=> {
-            //     msgController.setChannels(assertItem.setImageChannel[0]);
-            //     let VectorOverlayTileDataPromiseChannel1 = new Promise((resolve)=>{
-            //         msgController.vectorTileStream.subscribe({
-            //             next: (data) => {
-            //                 VectorOverlayTileDataArrayChannel1.push(data)
-            //                 if (data.progress === 1) {
-            //                     resolve(VectorOverlayTileDataArrayChannel1)
-            //                 }
-            //             }
-            //         });
-            //     });
+        describe(`(Case 2) Initialization: open the image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async() => {
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile[1]);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+                expect(RegionHistrogramDataResponse[0].progress).toEqual(assertItem.regionHistogramData[1].progress);
+                expect(RegionHistrogramDataResponse[0].regionId).toEqual(assertItem.regionHistogramData[1].regionId);
+                expect(RegionHistrogramDataResponse[0].fileId).toEqual(assertItem.regionHistogramData[1].fileId);
+                expect(RegionHistrogramDataResponse[0].histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData[1].histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistrogramDataResponse[0].histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData[1].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistrogramDataResponse[0].histograms.mean).toBeCloseTo(assertItem.regionHistogramData[1].histograms.mean, assertItem.precisionDigits);
+                expect(RegionHistrogramDataResponse[0].histograms.numBins).toEqual(assertItem.regionHistogramData[1].histograms.numBins);
+                expect(RegionHistrogramDataResponse[0].histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData[1].histograms.stdDev, assertItem.precisionDigits);
+            }, openFileTimeout);
 
-            //     let RasterTileData = [];
-            //     let RasterTileDataSync = [];
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                msgController.addRequiredTiles(assertItem.addTilesReq[1]);
+                let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                expect(RasterTileData[1].fileId).toEqual(assertItem.addTilesReq[1].fileId);
+                expect(JSON.stringify(RasterTileData[2])).toMatch(/{\"fileId\":1,\"endSync\":true}/)
+            }, openFileTimeout);
+        });
 
-            //     let RasterTileDataSyncPromise = new Promise((resolve) => {
-            //         msgController.rasterSyncStream.subscribe({
-            //             next: (data) => {
-            //                 RasterTileDataSync.push(data)
-            //                 if (data.endSync === true) {
-            //                     resolve(RasterTileDataSync)
-            //                 }
-            //             }
-            //         })
-            //     })
+        describe(`(Case 2) Open the second images, and set vector overlay, contour, and change channel:`, () => {
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request Vector Overlay and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[2]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
 
-            //     let RasterTileDataPromise = new Promise((resolve) => {
-            //         msgController.rasterTileStream.subscribe({
-            //             next: (data) => {
-            //                 RasterTileData.push(data)
-            //                 if (RasterTileData.length === assertItem.setImageChannel[0].requiredTiles.tiles.length) {
-            //                     resolve(RasterTileData)
-            //                 }
-            //             },
-            //         })
-            //     });
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
 
-            //     VectorOverlayTileDataResponseChannel1 = await VectorOverlayTileDataPromiseChannel1;
-            //     RegionHistogramData = await Stream(CARTA.RegionHistogramData, 1);
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[1].progress);
+                expect(lastVectorOverlayTileDataResponse.fileId).toEqual(assertItem.VectorOverlayTileData[1].fileId);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[1].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[1].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[1].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[1].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[1].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Set Contours parameter, Receive the Stream responses and check the correctness:`, async () => {
+                msgController.setContourParameters(assertItem.setContour[2]);
+                let ContourImageDataResponse: [] = await Stream(CARTA.ContourImageData, assertItem.setContour[0].levels.length);
+                assertItem.contourImageData.map((data)=>{
+                    let eachContourImageData: any[] = ContourImageDataResponse.filter(ResponseData => ResponseData.contourSets[0].level == data.contourSets[0].level);
+                    expect(eachContourImageData[0].progress).toEqual(data.progress);
+                    expect(eachContourImageData[0].contourSets[0].decimationFactor).toEqual(data.contourSets[0].decimationFactor);
+                    expect(eachContourImageData[0].contourSets[0].level).toEqual(data.contourSets[0].level);
+                    expect(eachContourImageData[0].contourSets[0].uncompressedCoordinatesSize).toEqual(data.contourSets[0].uncompressedCoordinatesSize);
+                    data.selectedCoordinateIndex.map((subdata, index) => {
+                        expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
+                    })
+                    data.selectedStartIndicesIndex.map((subdata, index) => {
+                        expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
+                    })
+                })
+            });
+
+            let VectorOverlayTileDataArrayChannel1 = [];
+            let VectorOverlayTileDataResponseChannel1: any;
+            let RegionHistogramData: any;
+            let RasterTileDataChannel1: any;
+            let RasterTileDataSyncChannel1: any;
+            let ContourImageDataResponse: [];
+            test(`(Step 4) Set Image (fileId = 1) Channel to 1 and Receive the three type ICD messages:`, async ()=> {
+                msgController.setChannels(assertItem.setImageChannel[0]);
+                let VectorOverlayTileDataPromiseChannel1 = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArrayChannel1.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArrayChannel1)
+                            }
+                        }
+                    });
+                });
+
+                let RasterTileData = [];
+                let RasterTileDataSync = [];
+
+                let RasterTileDataSyncPromise = new Promise((resolve) => {
+                    msgController.rasterSyncStream.subscribe({
+                        next: (data) => {
+                            RasterTileDataSync.push(data)
+                            if (data.endSync === true) {
+                                resolve(RasterTileDataSync)
+                            }
+                        }
+                    })
+                })
+
+                let RasterTileDataPromise = new Promise((resolve) => {
+                    msgController.rasterTileStream.subscribe({
+                        next: (data) => {
+                            RasterTileData.push(data)
+                            if (RasterTileData.length === assertItem.setImageChannel[0].requiredTiles.tiles.length) {
+                                resolve(RasterTileData)
+                            }
+                        },
+                    })
+                });
+
+                // msgController.setContourParameters(assertItem.setContour[0]);
+                ContourImageDataResponse = await Stream(CARTA.ContourImageData, assertItem.setContour[0].levels.length);
+
+                VectorOverlayTileDataResponseChannel1 = await VectorOverlayTileDataPromiseChannel1;
+                RegionHistogramData = await Stream(CARTA.RegionHistogramData, 1);
         
-            //     RasterTileDataChannel1 = await RasterTileDataPromise;
-            //     RasterTileDataSyncChannel1 = await RasterTileDataSyncPromise;
-            //     // console.log(RasterTileDataChannel1.length);
-            //     // console.log(RasterTileDataSyncChannel1);
-            // });
+                RasterTileDataChannel1 = await RasterTileDataPromise;
+                RasterTileDataSyncChannel1 = await RasterTileDataSyncPromise;
+            });
 
-            // test(`(Step 4: Verify the Response (the last VECTOR_OVERLAY_TILE_DATA of channel 1) correctness)`, () => {
-            //     let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponseChannel1.slice(-1)[0];
-            //     expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[1].progress);
-            //     expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[1].stokesAngle);
-            //     expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[1].stokesIntensity);
-            //     expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[1].compressionQuality);
-            //     expect(lastVectorOverlayTileDataResponse.channel).toEqual(assertItem.VectorOverlayTileData[1].channel);
+            test(`(Step 5) Verify the Responses (the all CONTOUR_IMAGE_DATA Stream messages of fileid 1 channel 1) correctness`, async () => {
+                assertItem.contourImageData2.map((data)=>{
+                    let eachContourImageData: any[] = ContourImageDataResponse.filter(ResponseData => ResponseData.contourSets[0].level == data.contourSets[0].level);
+                    expect(eachContourImageData[0].progress).toEqual(data.progress);
+                    expect(eachContourImageData[0].fileId).toEqual(data.fileId);
+                    expect(eachContourImageData[0].channel).toEqual(data.channel);
+                    expect(eachContourImageData[0].contourSets[0].decimationFactor).toEqual(data.contourSets[0].decimationFactor);
+                    expect(eachContourImageData[0].contourSets[0].level).toEqual(data.contourSets[0].level);
+                    expect(eachContourImageData[0].contourSets[0].uncompressedCoordinatesSize).toEqual(data.contourSets[0].uncompressedCoordinatesSize);
+                    data.selectedCoordinateIndex?.map((subdata, index) => {
+                        expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
+                    })
+                    data.selectedStartIndicesIndex?.map((subdata, index) => {
+                        expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
+                    })
+                })
+            });
 
-            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].height);
-            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].mip);
-            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].layer);
-            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].width);
-            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].x);
-            //     expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalAngleImageDataLength);
-            //     assertItem.VectorOverlayTileData[0].selectedAngleImageDataIndex.map((data, index) => {
-            //         expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedAngleImageDataValue[index])
-            //     });
+            test(`(Step 6: Verify the Response (the last VECTOR_OVERLAY_TILE_DATA of fileid 1 channel 1) correctness)`, () => {
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponseChannel1.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[2].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[2].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[2].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[2].compressionQuality);
+                expect(lastVectorOverlayTileDataResponse.channel).toEqual(assertItem.VectorOverlayTileData[2].channel);
 
-            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].height);
-            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].layer);
-            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].mip);
-            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].width);
-            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].x);
-            //     expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalIntensityImageDataLength);
-            //     assertItem.VectorOverlayTileData[0].selectedIntensityImageDataIndex.map((data, index) => {
-            //         expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedIntensityImageDataValue[index])
-            //     });
-            // })
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[2].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[2].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[2].selectedAngleImageDataValue[index])
+                });
 
-            // test(`(Step 5) Verify the Response (REGION_HISTOGRAM_DATA, RASTER_TILE, and RASTER_TILE_SYNC) correctness`, () => {
-            //     expect(RegionHistogramData[0].channel).toEqual(assertItem.regionHistogramData.channel);
-            //     expect(RegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
-            //     expect(RegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
-            //     expect(RegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.regionHistogramData.histograms.mean, assertItem.precisionDigits);
-            //     expect(RegionHistogramData[0].histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[2].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[2].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[2].selectedIntensityImageDataValue[index])
+                });
+            });
 
-            //     RasterTileDataChannel1.map((data) => {
-            //         expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
-            //     });
-            //     expect(RasterTileDataChannel1.length).toEqual(assertItem.setImageChannel[0].requiredTiles.tiles.length);
-            //     RasterTileDataSyncChannel1.map((data) => {
-            //         expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
-            //     })
-            //     expect(RasterTileDataSyncChannel1[1].endSync).toEqual(true);
-            // });
+            test(`(Step 7) Verify the Response (REGION_HISTOGRAM_DATA, RASTER_TILE, and RASTER_TILE_SYNC of fileid 1 channel 1) correctness`, () => {
+                expect(RegionHistogramData[0].channel).toEqual(assertItem.regionHistogramData[2].channel);
+                expect(RegionHistogramData[0].histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData[2].histograms.binWidth, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData[2].histograms.firstBinCenter, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.mean).toBeCloseTo(assertItem.regionHistogramData[2].histograms.mean, assertItem.precisionDigits);
+                expect(RegionHistogramData[0].histograms.numBins).toEqual(assertItem.regionHistogramData[2].histograms.numBins);
+
+                RasterTileDataChannel1.map((data) => {
+                    expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
+                });
+                expect(RasterTileDataChannel1.length).toEqual(assertItem.setImageChannel[0].requiredTiles.tiles.length);
+                RasterTileDataSyncChannel1.map((data) => {
+                    expect(data.channel).toEqual(assertItem.setImageChannel[0].channel);
+                })
+                expect(RasterTileDataSyncChannel1[1].endSync).toEqual(true);
+            });
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
+++ b/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
@@ -80,6 +80,11 @@ let assertItem: AssertItem = {
             threshold: NaN,
             uError: undefined
         },
+        {
+            fileId: 0,
+            stokesAngle: -1,
+            stokesIntensity: -1
+        },
     ],
     VectorOverlayTileData: [
         {
@@ -176,6 +181,10 @@ let assertItem: AssertItem = {
             decimationFactor: 4,
             compressionLevel: 8,
             contourChunkSize: 100000,
+        },
+        {
+            fileId: 0,
+            referenceFileId: 0,
         }
     ],
     contourImageData: [
@@ -319,6 +328,17 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
                         expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
                     })
                 })
+            });
+
+            test(`(Step 4) Clear Vector Overlay and Contours, and there is no any ICD message returned:`, done => {
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                msgController.setContourParameters(assertItem.setContour[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
             });
 
             // let VectorOverlayTileDataArrayChannel1 = [];

--- a/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
+++ b/src/test/VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts
@@ -20,11 +20,9 @@ interface IVectorOverlayTileDataExt extends CARTA.IVectorOverlayTileData {
 
 interface IContourImageDataExt extends CARTA.IContourImageData {
     totalCoordinate?: Number;
-    selectedCoordinateIndex?: Number[];
-    selectedCoordinateValue?: Number[];
     totalStartIndices?: Number;
-    selectedStartIndicesIndex?:  Number[];
-    selectedStartIndicesValue?: Number[];
+    // selectedStartIndicesIndex?:  Number[];
+    // selectedStartIndicesValue?: Number[];
 }
 
 interface AssertItem {
@@ -290,11 +288,11 @@ let assertItem: AssertItem = {
             }],
             progress: 1,
             totalCoordinate: 301,
-            selectedCoordinateIndex: [0,50, 100, 150, 200, 250],
-            selectedCoordinateValue: [40, 130, 189, 120, 142, 243],
+            // selectedCoordinateIndex: [0,50, 100, 150, 200, 250],
+            // selectedCoordinateValue: [40, 130, 189, 120, 142, 243],
             totalStartIndices: 48,
-            selectedStartIndicesIndex: [0, 20, 40],
-            selectedStartIndicesValue: [0, 118, 208]
+            // selectedStartIndicesIndex: [0, 20, 40],
+            // selectedStartIndicesValue: [0, 118, 208]
         },
         {
             contourSets: [{
@@ -304,11 +302,11 @@ let assertItem: AssertItem = {
             }],
             progress: 1,
             totalCoordinate: 4085,
-            selectedCoordinateIndex: [0, 500, 1000, 2500, 3500, 4000],
-            selectedCoordinateValue: [40, 191, 159, 143, 79, 196],
+            // selectedCoordinateIndex: [0, 500, 1000, 2500, 3500, 4000],
+            // selectedCoordinateValue: [40, 191, 159, 143, 79, 196],
             totalStartIndices: 780,
-            selectedStartIndicesIndex: [0, 50, 100, 350, 500, 750],
-            selectedStartIndicesValue: [0, 0, 10, 0, 46, 0]
+            // selectedStartIndicesIndex: [0, 50, 100, 350, 500, 750],
+            // selectedStartIndicesValue: [0, 0, 10, 0, 46, 0]
         },
         {
             contourSets: [{
@@ -318,11 +316,11 @@ let assertItem: AssertItem = {
             }],
             progress: 1,
             totalCoordinate: 47845,
-            selectedCoordinateIndex: [0, 500, 1000, 7500, 10000, 13000, 22000, 35000, 41000, 45000],
-            selectedCoordinateValue: [40, 254, 82, 128, 252, 96, 166, 18, 118, 15],
+            // selectedCoordinateIndex: [0, 500, 1000, 7500, 10000, 13000, 22000, 35000, 41000, 45000],
+            // selectedCoordinateValue: [40, 254, 82, 128, 252, 96, 166, 18, 118, 15],
             totalStartIndices: 6396,
-            selectedStartIndicesIndex: [0, 500, 1000, 2000, 3000, 4000, 6000],
-            selectedStartIndicesValue: [0, 174, 32, 36,  108, 196, 220]
+            // selectedStartIndicesIndex: [0, 500, 1000, 2000, 3000, 4000, 6000],
+            // selectedStartIndicesValue: [0, 174, 32, 36,  108, 196, 220]
         },
     ],
     contourImageData2: [
@@ -356,11 +354,11 @@ let assertItem: AssertItem = {
             progress: 1,
             channel: 1,
             totalCoordinate: 503,
-            selectedCoordinateIndex: [0, 50, 100, 200, 300, 400, 500],
-            selectedCoordinateValue: [40, 42, 41, 235, 131, 11, 114],
+            // selectedCoordinateIndex: [0, 50, 100, 200, 300, 400, 500],
+            // selectedCoordinateValue: [40, 42, 41, 235, 131, 11, 114],
             totalStartIndices: 64,
-            selectedStartIndicesIndex: [0, 10, 20, 30, 40, 50, 60],
-            selectedStartIndicesValue: [0, 0, 142, 0, 44, 0, 6]
+            // selectedStartIndicesIndex: [0, 10, 20, 30, 40, 50, 60],
+            // selectedStartIndicesValue: [0, 0, 142, 0, 44, 0, 6]
         },
     ],
     precisionDigits: 8,
@@ -454,12 +452,12 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
                     expect(eachContourImageData[0].contourSets[0].decimationFactor).toEqual(data.contourSets[0].decimationFactor);
                     expect(eachContourImageData[0].contourSets[0].level).toEqual(data.contourSets[0].level);
                     expect(eachContourImageData[0].contourSets[0].uncompressedCoordinatesSize).toEqual(data.contourSets[0].uncompressedCoordinatesSize);
-                    data.selectedCoordinateIndex.map((subdata, index) => {
-                        expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
-                    })
-                    data.selectedStartIndicesIndex.map((subdata, index) => {
-                        expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
-                    })
+                    // data.selectedCoordinateIndex.map((subdata, index) => {
+                    //     expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
+                    // })
+                    // data.selectedStartIndicesIndex.map((subdata, index) => {
+                    //     expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
+                    // })
                 })
             });
 
@@ -555,12 +553,12 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
                     expect(eachContourImageData[0].contourSets[0].decimationFactor).toEqual(data.contourSets[0].decimationFactor);
                     expect(eachContourImageData[0].contourSets[0].level).toEqual(data.contourSets[0].level);
                     expect(eachContourImageData[0].contourSets[0].uncompressedCoordinatesSize).toEqual(data.contourSets[0].uncompressedCoordinatesSize);
-                    data.selectedCoordinateIndex.map((subdata, index) => {
-                        expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
-                    })
-                    data.selectedStartIndicesIndex.map((subdata, index) => {
-                        expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
-                    })
+                    // data.selectedCoordinateIndex.map((subdata, index) => {
+                    //     expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
+                    // })
+                    // data.selectedStartIndicesIndex.map((subdata, index) => {
+                    //     expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
+                    // })
                 })
             });
 
@@ -627,12 +625,12 @@ describe("VECTOR_OVERLAY_CONTOUR_CHANNEL: Testing the vector overlay ICD message
                     expect(eachContourImageData[0].contourSets[0].decimationFactor).toEqual(data.contourSets[0].decimationFactor);
                     expect(eachContourImageData[0].contourSets[0].level).toEqual(data.contourSets[0].level);
                     expect(eachContourImageData[0].contourSets[0].uncompressedCoordinatesSize).toEqual(data.contourSets[0].uncompressedCoordinatesSize);
-                    data.selectedCoordinateIndex?.map((subdata, index) => {
-                        expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
-                    })
-                    data.selectedStartIndicesIndex?.map((subdata, index) => {
-                        expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
-                    })
+                    // data.selectedCoordinateIndex?.map((subdata, index) => {
+                    //     expect(eachContourImageData[0].contourSets[0].rawCoordinates[subdata]).toEqual(data.selectedCoordinateValue[index]);
+                    // })
+                    // data.selectedStartIndicesIndex?.map((subdata, index) => {
+                    //     expect(eachContourImageData[0].contourSets[0].rawStartIndices[subdata]).toEqual(data.selectedStartIndicesValue[index]);
+                    // })
                 })
             });
 

--- a/src/test/VECTOR_OVERLAY_FITS.test.ts
+++ b/src/test/VECTOR_OVERLAY_FITS.test.ts
@@ -94,6 +94,62 @@ let assertItem: AssertItem = {
             threshold: NaN,
             uError: undefined
         },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: 0.01,
+            uError: undefined
+        },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: true,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: 0.01,
+            smoothingFactor: 2,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: 0.01,
+            uError: 0.01
+        },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: 1,
+            stokesIntensity: -1,
+            threshold: NaN,
+            uError: undefined
+        },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: -1,
+            stokesIntensity: 1,
+            threshold: NaN,
+            uError: undefined
+        },
     ],
     VectorOverlayTileData: [
         {
@@ -151,7 +207,125 @@ let assertItem: AssertItem = {
             selectedAngleImageDataValue: [0, 192, 0, 127, 192],
             selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
             selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
-        }
+        },
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        },
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        },
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 676,
+            angleTiles: [{
+                height: 13,
+                layer: 2,
+                mip: 2,
+                width: 13,
+                x: 2,
+                y: 2
+            }],
+            totalIntensityImageDataLength: 676,
+            intensityTiles: [{
+                height: 13,
+                layer: 2,
+                mip: 2,
+                width: 13,
+                x: 2,
+                y: 2
+            }],
+            selectedAngleImageDataIndex: [2,200, 402, 600, 671],
+            selectedAngleImageDataValue: [192, 0, 192, 0, 127],
+            selectedIntensityImageDataIndex: [2,200, 402, 600, 671],
+            selectedIntensityImageDataValue: [192, 0, 192, 0, 127],
+        },
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: -1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+        },
+        {
+            progress: 1, 
+            stokesAngle: -1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        },
     ]
 };
 
@@ -325,6 +499,255 @@ describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
 
                 VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
             }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[2].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[2].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[2].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[2].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[2].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[2].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[2].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[2].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[2].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[2].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[1].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[2].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        describe(`(Case 4) With smoothing of 4, polarization intensity of absolute, and threshold of 0.01:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                await sleep(500);
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[4]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[3].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[3].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[3].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[3].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[3].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[3].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[3].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[3].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[3].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[3].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[3].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[3].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[3].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[3].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[3].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[3].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[3].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[1].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[3].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        describe(`(Case 5) With smoothing of 2, polarization intensity of absolute, threshold of 0.01 and stoke Q error of 0.01 and stoke U error of 0.01:`, () => {
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                await sleep(500);
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[5]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[4].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[4].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[4].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[4].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[4].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[4].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[4].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[4].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[4].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[4].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[4].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[4].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[4].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[4].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[4].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[4].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[4].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[4].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[4].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        describe(`(Case 6) Only computed PA with smoothing of 4:`, () => {
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                await sleep(500);
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[6]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[5].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[5].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[5].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[5].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[5].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[5].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[5].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[5].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[5].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[5].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[5].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0]).toEqual({});
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        describe(`(Case 7) Only computed PI with smoothing of 4:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                await sleep(500);
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[7]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[6].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[6].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[6].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[6].compressionQuality);
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[6].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[6].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[6].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[6].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[6].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[6].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[6].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[6].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
         });
 
         afterAll(() => msgController.closeConnection());

--- a/src/test/VECTOR_OVERLAY_FITS.test.ts
+++ b/src/test/VECTOR_OVERLAY_FITS.test.ts
@@ -1,0 +1,110 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let openFileTimeout: number = config.timeout.openFile;
+let connectTimeout: number = config.timeout.connection;
+let vectorOverlayTimeout: number = config.timeout.vectorOverlay;
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setVectorOverlayParameters: CARTA.ISetVectorOverlayParameters[];
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HH211_IQU.fits",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setVectorOverlayParameters: [
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 1,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: NaN,
+            uError: undefined
+        },
+    ]
+};
+
+let basepath: string;
+describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Initialization: open the image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async() => {
+                msgController.closeFile(-1);
+                msgController.closeFile(0);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            }, openFileTimeout);
+
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                msgController.addRequiredTiles(assertItem.addTilesReq);
+                let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                expect(JSON.stringify(RasterTileData[2])).toMatch(/{\"endSync\":true}/)
+            }, openFileTimeout);
+        });
+
+        describe(`(Case 1) Only polarization intensity: Absolute:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[0]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                let VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+                console.log(VectorOverlayTileDataResponse);
+            }, vectorOverlayTimeout);
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/VECTOR_OVERLAY_FITS.test.ts
+++ b/src/test/VECTOR_OVERLAY_FITS.test.ts
@@ -9,12 +9,22 @@ let openFileTimeout: number = config.timeout.openFile;
 let connectTimeout: number = config.timeout.connection;
 let vectorOverlayTimeout: number = config.timeout.vectorOverlay;
 
+interface IVectorOverlayTileDataExt extends CARTA.IVectorOverlayTileData {
+    totalAngleImageDataLength?: Number;
+    totalIntensityImageDataLength?: Number;
+    selectedAngleImageDataIndex?: Number[];
+    selectedAngleImageDataValue?: Number[];
+    selectedIntensityImageDataIndex?: Number[];
+    selectedIntensityImageDataValue?: Number[];
+}
+
 interface AssertItem {
     registerViewer: CARTA.IRegisterViewer;
     filelist: CARTA.IFileListRequest;
     openFile: CARTA.IOpenFile;
     addTilesReq: CARTA.IAddRequiredTiles;
     setVectorOverlayParameters: CARTA.ISetVectorOverlayParameters[];
+    VectorOverlayTileData : IVectorOverlayTileDataExt[]
 };
 
 let assertItem: AssertItem = {
@@ -51,8 +61,103 @@ let assertItem: AssertItem = {
             threshold: NaN,
             uError: undefined
         },
+        {
+            fileId: 0,
+            stokesAngle: -1,
+            stokesIntensity: -1
+        },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: NaN,
+            uError: undefined
+        },
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: true,
+            imageBounds: { xMin: 0, xMax: 1049, yMin: 0, yMax: 1049},
+            qError: undefined,
+            smoothingFactor: 4,
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            threshold: NaN,
+            uError: undefined
+        },
+    ],
+    VectorOverlayTileData: [
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 2500,
+            angleTiles: [{
+                height: 25,
+                mip: 1,
+                layer: 3,
+                width: 25,
+                x: 4,
+                y: 4
+            }],
+            totalIntensityImageDataLength: 2500,
+            intensityTiles: [{
+                height: 25,
+                layer: 3,
+                mip: 1,
+                width: 25,
+                x: 4,
+                y: 4
+            }],
+            selectedAngleImageDataIndex: [3,501, 1002,1500, 2000, 2499],
+            selectedAngleImageDataValue: [127, 0, 192, 0, 0, 127],
+            selectedIntensityImageDataIndex: [3,501, 1002,1500, 2000, 2499],
+            selectedIntensityImageDataValue: [127, 0, 192, 0, 0, 127],
+        }, 
+        {
+            progress: 1, 
+            stokesAngle: 1,
+            stokesIntensity: 1,
+            compressionQuality: 8,
+            totalAngleImageDataLength: 196,
+            angleTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 196,
+            intensityTiles: [{
+                height: 7,
+                layer: 1,
+                mip: 4,
+                width: 7,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0,50, 100, 143, 190],
+            selectedAngleImageDataValue: [0, 192, 0, 127, 192],
+            selectedIntensityImageDataIndex: [0,50, 100, 143, 190],
+            selectedIntensityImageDataValue: [0, 192, 0, 127, 192],
+        }
     ]
 };
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms)).then(() => {});
+}
 
 let basepath: string;
 describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
@@ -85,8 +190,9 @@ describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
             }, openFileTimeout);
         });
 
-        describe(`(Case 1) Only polarization intensity: Absolute:`, ()=>{
+        describe(`(Case 1) Only polarization intensity of Absolute:`, ()=>{
             let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
             test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
                 msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[0]);
                 let VectorOverlayTileDataPromise = new Promise((resolve)=>{
@@ -100,8 +206,124 @@ describe("PV_GENERATOR_FITS:Testing PV generator with fits file.", () => {
                     });
                 });
 
-                let VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
-                console.log(VectorOverlayTileDataResponse);
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[0].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[0].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[0].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[0].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        describe(`(Case 2) With smoothing factor of 4:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                await sleep(500);
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[2]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[1].progress);
+                expect(lastVectorOverlayTileDataResponse.stokesAngle).toEqual(assertItem.VectorOverlayTileData[1].stokesAngle);
+                expect(lastVectorOverlayTileDataResponse.stokesIntensity).toEqual(assertItem.VectorOverlayTileData[1].stokesIntensity);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[1].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[1].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[1].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[1].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[1].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[1].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        describe(`(Case 3) With smoothing of 4 and polarization intensity of fractional:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                await sleep(500);
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[3]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
             }, vectorOverlayTimeout);
         });
 

--- a/src/test/VECTOR_OVERLAY_HDF5.test.ts
+++ b/src/test/VECTOR_OVERLAY_HDF5.test.ts
@@ -35,8 +35,8 @@ let assertItem: AssertItem = {
     filelist: { directory: testSubdirectory },
     openFile: {
         directory: testSubdirectory,
-        file: "HH211_IQU.fits",
-        hdu: "",
+        file: "HH211_IQU.hdf5",
+        hdu: "0",
         fileId: 0,
         renderMode: CARTA.RenderMode.RASTER,
     },
@@ -334,7 +334,7 @@ function sleep(ms) {
 }
 
 let basepath: string;
-describe("VECTOR_OVERLAY_FITS: Testing the vector overlay ICD messages with the polarization fits image", () => {
+describe("VECTOR_OVERLAY_HDF5: Testing the vector overlay ICD messages with the polarization hdf5 image", () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async ()=> {

--- a/src/test/VECTOR_OVERLAY_NO_POLARIZATION.test.ts
+++ b/src/test/VECTOR_OVERLAY_NO_POLARIZATION.test.ts
@@ -102,7 +102,7 @@ function sleep(ms) {
 }
 
 let basepath: string;
-describe("VVECTOR_OVERLAY_NO_POLARIZATION: Testing the vector overlay ICD messages with the NONE polarization fits image", () => {
+describe("VECTOR_OVERLAY_NO_POLARIZATION: Testing the vector overlay ICD messages with the NONE polarization fits image", () => {
     const msgController = MessageController.Instance;
     describe(`Register a session`, () => {
         beforeAll(async ()=> {
@@ -132,7 +132,7 @@ describe("VVECTOR_OVERLAY_NO_POLARIZATION: Testing the vector overlay ICD messag
             }, openFileTimeout);
         });
 
-        describe(`(Case 1) Only polarization intensity of Absolute:`, ()=>{
+        describe(`Request Vector Overlay ICD messages with NONE polarization fits image (${assertItem.openFile.file})`, ()=>{
             let VectorOverlayTileDataArray = [];
             let VectorOverlayTileDataResponse: any;
             test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {

--- a/src/test/VECTOR_OVERLAY_NO_POLARIZATION.test.ts
+++ b/src/test/VECTOR_OVERLAY_NO_POLARIZATION.test.ts
@@ -1,0 +1,193 @@
+import { CARTA } from "carta-protobuf";
+import { checkConnection, Stream} from './myClient';
+import { MessageController } from "./MessageController";
+import config from "./config.json";
+
+let testServerUrl: string = config.serverURL0;
+let testSubdirectory: string = config.path.QA;
+let openFileTimeout: number = config.timeout.openFile;
+let connectTimeout: number = config.timeout.connection;
+let vectorOverlayTimeout: number = config.timeout.vectorOverlay;
+
+interface IVectorOverlayTileDataExt extends CARTA.IVectorOverlayTileData {
+    totalAngleImageDataLength?: Number;
+    totalIntensityImageDataLength?: Number;
+    selectedAngleImageDataIndex?: Number[];
+    selectedAngleImageDataValue?: Number[];
+    selectedIntensityImageDataIndex?: Number[];
+    selectedIntensityImageDataValue?: Number[];
+}
+
+interface AssertItem {
+    registerViewer: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setVectorOverlayParameters: CARTA.ISetVectorOverlayParameters[];
+    VectorOverlayTileData : IVectorOverlayTileDataExt[]
+};
+
+let assertItem: AssertItem = {
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    openFile: {
+        directory: testSubdirectory,
+        file: "M17_SWex.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setVectorOverlayParameters: [
+        {
+            compressionQuality: 8,
+            compressionType: CARTA.CompressionType.NONE,
+            debiasing: false,
+            fileId: 0,
+            fractional: false,
+            imageBounds: { xMin: 0, xMax: 650, yMin: 0, yMax: 800},
+            qError: undefined,
+            smoothingFactor: 2,
+            stokesAngle: 0,
+            stokesIntensity: 0,
+            threshold: NaN,
+            uError: undefined
+        },
+        {
+            fileId: 0,
+            stokesAngle: -1,
+            stokesIntensity: -1
+        },
+    ],
+    VectorOverlayTileData: [
+        {
+            progress: 1, 
+            compressionQuality: 8,
+            totalAngleImageDataLength: 36864,
+            angleTiles: [{
+                height: 144,
+                mip: 2,
+                layer: 1,
+                width: 64,
+                x: 1,
+                y: 1
+            }],
+            totalIntensityImageDataLength: 36864,
+            intensityTiles: [{
+                height: 144,
+                layer: 1,
+                mip: 2,
+                width: 64,
+                x: 1,
+                y: 1
+            }],
+            selectedAngleImageDataIndex: [0, 11, 67, 1002, 5000, 20002, 30303, 35000],
+            selectedAngleImageDataValue: [70, 187, 187, 192, 0, 192, 127, 0],
+            selectedIntensityImageDataIndex: [0, 11, 67, 1002, 5000, 20002, 30303, 35000],
+            selectedIntensityImageDataValue: [70, 187, 187, 192, 0, 192, 127, 0],
+        }, 
+    ]
+};
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms)).then(() => {});
+}
+
+let basepath: string;
+describe("VVECTOR_OVERLAY_NO_POLARIZATION: Testing the vector overlay ICD messages with the NONE polarization fits image", () => {
+    const msgController = MessageController.Instance;
+    describe(`Register a session`, () => {
+        beforeAll(async ()=> {
+            await msgController.connect(testServerUrl);
+        }, connectTimeout);
+
+        checkConnection();
+        test(`Get basepath and modify the directory path`, async () => {
+            let fileListResponse = await msgController.getFileList("$BASE",0);
+            basepath = fileListResponse.directory;
+            assertItem.openFile.directory = basepath + "/" + assertItem.openFile.directory;
+        });
+
+        describe(`Initialization: open the image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async() => {
+                msgController.closeFile(-1);
+                msgController.closeFile(0);
+                let OpenFileResponse = await msgController.loadFile(assertItem.openFile);
+                expect(OpenFileResponse.success).toEqual(true);
+                let RegionHistrogramDataResponse = await Stream(CARTA.RegionHistogramData,1);
+            }, openFileTimeout);
+
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                msgController.addRequiredTiles(assertItem.addTilesReq);
+                let RasterTileData = await Stream(CARTA.RasterTileData,3); //RasterTileData * 1 + RasterTileSync * 2
+                expect(JSON.stringify(RasterTileData[2])).toMatch(/{\"endSync\":true}/)
+            }, openFileTimeout);
+        });
+
+        describe(`(Case 1) Only polarization intensity of Absolute:`, ()=>{
+            let VectorOverlayTileDataArray = [];
+            let VectorOverlayTileDataResponse: any;
+            test(`(Step 1) Request and Response should arrived within ${vectorOverlayTimeout} ms`, async() => {
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[0]);
+                let VectorOverlayTileDataPromise = new Promise((resolve)=>{
+                    msgController.vectorTileStream.subscribe({
+                        next: (data) => {
+                            VectorOverlayTileDataArray.push(data)
+                            if (data.progress === 1) {
+                                resolve(VectorOverlayTileDataArray)
+                            }
+                        }
+                    });
+                });
+
+                VectorOverlayTileDataResponse = await VectorOverlayTileDataPromise;
+            }, vectorOverlayTimeout);
+
+            test(`(Step 2) Verify the Response (the last VECTOR_OVERLAY_TILE_DATA) correctness`, ()=>{
+                let lastVectorOverlayTileDataResponse = VectorOverlayTileDataResponse.slice(-1)[0];
+                expect(lastVectorOverlayTileDataResponse.progress).toEqual(assertItem.VectorOverlayTileData[0].progress);
+                expect(lastVectorOverlayTileDataResponse.compressionQuality).toEqual(assertItem.VectorOverlayTileData[0].compressionQuality);
+                
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].angleTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalAngleImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedAngleImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.angleTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedAngleImageDataValue[index])
+                });
+
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].height).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].height);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].layer).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].layer);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].mip).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].mip);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].width).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].width);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].x).toEqual(assertItem.VectorOverlayTileData[0].intensityTiles[0].x);
+                expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData.length).toEqual(assertItem.VectorOverlayTileData[0].totalIntensityImageDataLength);
+                assertItem.VectorOverlayTileData[0].selectedIntensityImageDataIndex.map((data, index) => {
+                    expect(lastVectorOverlayTileDataResponse.intensityTiles[0].imageData[data]).toEqual(assertItem.VectorOverlayTileData[0].selectedIntensityImageDataValue[index])
+                });
+            });
+
+            test(`(Step 3) Clear Vector Overlay ICD`, done =>{
+                msgController.setVectorOverlayParameters(assertItem.setVectorOverlayParameters[1]);
+                let receiveNumberCurrent = msgController.messageReceiving();
+                setTimeout(() => {
+                    let receiveNumberLatter = msgController.messageReceiving();
+                    expect(receiveNumberCurrent).toEqual(receiveNumberLatter); //Have received number is equal during 1000 ms
+                    done();
+                }, 500)
+            });
+        });
+
+        afterAll(() => msgController.closeConnection());
+    });
+});

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -50,7 +50,8 @@
         "concatStokes": 3000,
         "openLargeFiles": 60000,
         "pvRequest": 60000,
-        "imageFitting": 60000
+        "imageFitting": 60000,
+        "vectorOverlay": 6000
     },
     "repeat": {
         "concurrent": 10,


### PR DESCRIPTION
This PR is adding the ICD tests for Vector Overlay ICD messages. 
So far all the tests are passed in three platforms: Ubuntu 22.04, Mac 11.6, and Mac 12.4.

However I found there is an issue related to other ICD message: CONTOUR_IMAGE_DATA
the rawCoordinates may return different values (encode integral) in Ubuntu OS and MacOS.
This new found issue will be separate from this PR and will open other issue to investigate in more detail. 
(I mark the grey color inside the [document](https://docs.google.com/document/d/18hN4UFud6AMwB0Ghe6_Jg1Z0-j_heFlO1-fKGRdhRZA/edit#) and block the corresponding inside the test case: VECTOR_OVERLAY_CONTOUR_CHANNEL.test.ts )